### PR TITLE
Add initial makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 
 before_install:
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure
+  - make dep-vendor
 
 install:
   - go get github.com/alecthomas/gometalinter
@@ -21,7 +21,7 @@ script:
   - gometalinter --vendor ./...
 
 # Execute tests and generate coverage for all the packages except fakes and tests
-  - go test ./... -coverpkg $(go list ./... | egrep -v "fakes|test" | paste -sd "," -) -coverprofile=profile.cov
+  - make test
   - goveralls -coverprofile profile.cov -service=travis-ci
   
   #Execute security scan

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# Copyright 2018 The Service Manager Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: build test
+
+BINDIR ?= bin
+TEST_PROFILE ?= $(CURDIR)/profile.cov
+COVERAGE ?= $(CURDIR)/coverage.html
+PROJECT_PKG = github.com/Peripli/service-broker-proxy-cf
+
+PLATFORM ?= linux
+ARCH     ?= amd64
+
+BUILD_LDFLAGS =
+
+#  GOFLAGS -  extra "go build" flags to use - e.g. -v   (for verbose)
+GO_BUILD = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) \
+           go build $(GOFLAGS) -ldflags '-s -w $(BUILD_LDFLAGS)'
+
+build: .init dep-vendor cf-sbproxy
+
+dep-check:
+	@which dep 2>/dev/null || (echo dep is required to build the project; exit 1)
+
+dep: dep-check
+	@dep ensure -v
+
+dep-vendor: dep-check
+	@dep ensure --vendor-only -v
+
+dep-reload: dep-check clean-vendor dep
+
+cf-sbproxy: $(BINDIR)/cf-sbproxy
+
+# Build cf service-broker-proxy under ./bin/cf-sbproxy
+$(BINDIR)/cf-sbproxy: .init .
+	 $(GO_BUILD) -o $@ $(PROJECT_PKG)
+
+# init creates the bin dir
+.init: $(BINDIR)
+
+$(BINDIR):
+	mkdir -p $@
+
+test: build
+	@echo Running tests:
+	@go test ./... -p 1 -race -coverpkg $(shell go list ./... | egrep -v "fakes|test" | paste -sd "," -) -coverprofile=$(TEST_PROFILE)
+
+coverage: build test
+	@go tool cover -html=$(TEST_PROFILE) -o "$(COVERAGE)"
+
+clean: clean-bin clean-test clean-coverage
+
+clean-bin:
+	rm -rf $(BINDIR)
+
+clean-test:
+	rm -f $(TEST_PROFILE)
+
+clean-coverage:
+	rm -f $(COVERAGE)
+
+clean-vendor:
+	rm -rf vendor
+	@echo > Gopkg.lock

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ARCH     ?= amd64
 
 BUILD_LDFLAGS =
 
-#  GOFLAGS -  extra "go build" flags to use - e.g. -v   (for verbose)
+# GO_FLAGS - extra "go build" flags to use - e.g. -v (for verbose)
 GO_BUILD = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) \
-           go build $(GOFLAGS) -ldflags '-s -w $(BUILD_LDFLAGS)'
+           go build $(GO_FLAGS) -ldflags '-s -w $(BUILD_LDFLAGS)'
 
 build: .init dep-vendor cf-sbproxy
 
@@ -44,7 +44,7 @@ dep-reload: dep-check clean-vendor dep
 cf-sbproxy: $(BINDIR)/cf-sbproxy
 
 # Build cf service-broker-proxy under ./bin/cf-sbproxy
-$(BINDIR)/cf-sbproxy: .init .
+$(BINDIR)/cf-sbproxy: .init
 	 $(GO_BUILD) -o $@ $(PROJECT_PKG)
 
 # init creates the bin dir
@@ -57,7 +57,7 @@ test: build
 	@echo Running tests:
 	@go test ./... -p 1 -race -coverpkg $(shell go list ./... | egrep -v "fakes|test" | paste -sd "," -) -coverprofile=$(TEST_PROFILE)
 
-coverage: build test
+coverage: test
 	@go tool cover -html=$(TEST_PROFILE) -o "$(COVERAGE)"
 
 clean: clean-bin clean-test clean-coverage


### PR DESCRIPTION
To simplify and unify the development of all components, makefile is added to the proxies as well to the service-manager

These PRs in all proxies are to add initial makefile. Improvements which affect all repositories (cf-proxy, k8s-proxy, proxy-core, service-manager) should be addressed in a separate issue - https://github.com/Peripli/service-manager/issues/170