### PR TITLE
Override environment variables with VCAP values only when values are missing

### DIFF
--- a/cf/env.go
+++ b/cf/env.go
@@ -38,6 +38,6 @@ func setMissingEnvironmentVariables(env env.Environment, envPairs ...envPair) {
 	}
 }
 
-func isZeroOfUnderlyingType(x interface{}) bool {
-	return reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
+func isZeroOfUnderlyingType(v interface{}) bool {
+	return reflect.DeepEqual(v, reflect.Zero(reflect.TypeOf(v)).Interface())
 }

--- a/cf/env.go
+++ b/cf/env.go
@@ -16,7 +16,6 @@ func SetCFOverrides(env env.Environment) error {
 			return fmt.Errorf("could not load VCAP environment: %s", err)
 		}
 
-		env.Set("app.url", "https://"+cfEnv.ApplicationURIs[0])
 		env.Set("server.port", cfEnv.Port)
 		env.Set("cf.client.apiAddress", cfEnv.CFAPI)
 	}

--- a/cf/env.go
+++ b/cf/env.go
@@ -32,7 +32,8 @@ func SetCFOverrides(env env.Environment) error {
 
 func setMissingEnvironmentVariables(env env.Environment, envPairs ...envPair) {
 	for _, pair := range envPairs {
-		if isZeroOfUnderlyingType(env.Get(pair.key)) {
+		currVal := env.Get(pair.key)
+		if currVal == nil || isZeroOfUnderlyingType(currVal) {
 			env.Set(pair.key, pair.value)
 		}
 	}

--- a/cf/env_test.go
+++ b/cf/env_test.go
@@ -69,16 +69,46 @@ var _ = Describe("CF Env", func() {
 		})
 
 		Context("when VCAP_APPLICATION is present", func() {
-			It("sets server.port", func() {
-				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+			Context("no env values already", func() {
+				It("sets app.url", func() {
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
 
-				Expect(environment.Get("server.port")).To(Equal(8080))
+					Expect(environment.Get("app.url")).To(Equal("https://example.com"))
+				})
+
+				It("sets server.port", func() {
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("server.port")).To(Equal(8080))
+				})
+
+				It("sets cf.client.apiAddress", func() {
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("cf.client.apiAddress")).To(Equal("https://example.com"))
+				})
 			})
+			Context("default env values are set", func() {
+				It("overrides app.url", func() {
+					environment.Set("app.url", "")
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
 
-			It("sets cf.client.apiAddress", func() {
-				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+					Expect(environment.Get("app.url")).To(Equal("https://example.com"))
+				})
 
-				Expect(environment.Get("cf.client.apiAddress")).To(Equal("https://example.com"))
+				It("overrides server.port", func() {
+					environment.Set("server.port", 0)
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("server.port")).To(Equal(8080))
+				})
+
+				It("overrides cf.client.apiAddress", func() {
+					environment.Set("cf.client.apiAddress", "")
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("cf.client.apiAddress")).To(Equal("https://example.com"))
+				})
 			})
 		})
 	})

--- a/cf/env_test.go
+++ b/cf/env_test.go
@@ -69,12 +69,6 @@ var _ = Describe("CF Env", func() {
 		})
 
 		Context("when VCAP_APPLICATION is present", func() {
-			It("sets app.url", func() {
-				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
-
-				Expect(environment.Get("app.url")).To(Equal("https://example.com"))
-			})
-
 			It("sets server.port", func() {
 				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
 

--- a/cf/env_test.go
+++ b/cf/env_test.go
@@ -69,7 +69,7 @@ var _ = Describe("CF Env", func() {
 		})
 
 		Context("when VCAP_APPLICATION is present", func() {
-			Context("no env values already", func() {
+			Context("no env values are already set", func() {
 				It("sets app.url", func() {
 					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
 
@@ -108,6 +108,28 @@ var _ = Describe("CF Env", func() {
 					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
 
 					Expect(environment.Get("cf.client.apiAddress")).To(Equal("https://example.com"))
+				})
+			})
+			Context("explicit env values are set", func() {
+				It("doesn't override app.url", func() {
+					environment.Set("app.url", "https://explicit-url.com")
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("app.url")).To(Equal("https://explicit-url.com"))
+				})
+
+				It("doesn't override server.port", func() {
+					environment.Set("server.port", 8000)
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("server.port")).To(Equal(8000))
+				})
+
+				It("doesn't override cf.client.apiAddress", func() {
+					environment.Set("cf.client.apiAddress", "https://explicit-url.com")
+					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+
+					Expect(environment.Get("cf.client.apiAddress")).To(Equal("https://explicit-url.com"))
 				})
 			})
 		})


### PR DESCRIPTION
# Override environment variables with VCAP values only when values are missing

There are times when environment values are already set for the SBP-CF and the VCAP values shouldn't override the already set values in these cases.