### PR TITLE
Fix unlimited go routines

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,8 @@
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:a52ec122222a862364c8f8b8594eb7453c87a60425aa2d76f8f1729cd5cd7e94"
+  branch = "fix-proxy"
+  digest = "1:0248009c3419fcbe93e5b6dbacad55efe2ffe7e61362798305572a0784fae424"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/filter",
@@ -31,8 +32,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "eb5242e85fa97b81f3122b3e73a4f070599869aa"
-  version = "v0.4.4"
+  revision = "152070c265543f3d1f5eb4578b31c3922dc7c3b6"
 
 [[projects]]
   digest = "1:7a122bb0965a9f0f3b4f9a6a0a5c154602cf4a8847cfea7b256ebf5af30e3d88"
@@ -69,11 +69,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a965e93173d9b30de4cc01c4a2aaaaa0478ece976f56dabb6e662800abf21011"
+  digest = "1:8597ea40ac83a647f7f67db149d1f0921d7baf873d2fd14ee3e475adeecae0ae"
   name = "github.com/cloudfoundry-community/go-cfclient"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f136f9222381e2fea5099f62e4b751dcb660ff82"
+  revision = "16c98753d3152f9d80d3c121523536858095a3da"
 
 [[projects]]
   digest = "1:d5fa6328bd281ac91e7b5d3f45b49f8ac36c30b6a530f633d91c6eaef50cd137"
@@ -396,7 +396,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "f99c8df09eb5bff426315721bfa5f16a99cad32c"
+  revision = "5c40567a22f818bd14a1ea7245dad9f8ef0691aa"
 
 [[projects]]
   branch = "master"
@@ -410,7 +410,7 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "60506f45cf65977eb3a9c6e30f995f54a721c271"
+  revision = "d28f0bde5980168871434b95cfc858db9f2a7a99"
 
 [[projects]]
   branch = "master"
@@ -426,11 +426,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8f5108406bc43c7669b0d67d282e40d05c9f268615fcaf8c1f0f76965aa3f09f"
+  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "4c4f7f33c9ed00de01c4c741d2177abfcfe19307"
+  revision = "d442b75600c5d6484576502b3c53a55c54311be9"
 
 [[projects]]
   digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"
@@ -476,8 +476,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "4c25cacc810c02874000e4f7071286a8e96b2515"
-  version = "v1.6.0"
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
 
 [[projects]]
   branch = "fix-proxy"
-  digest = "1:0248009c3419fcbe93e5b6dbacad55efe2ffe7e61362798305572a0784fae424"
+  digest = "1:e0294974a4b59206739aebc73d62b1a1bf6fc1973ee1d6c255f2b1c0f519dce1"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/filter",
@@ -32,7 +32,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "152070c265543f3d1f5eb4578b31c3922dc7c3b6"
+  revision = "61a84af73542a0dfbb575c869d5438465737283d"
 
 [[projects]]
   digest = "1:7a122bb0965a9f0f3b4f9a6a0a5c154602cf4a8847cfea7b256ebf5af30e3d88"
@@ -426,11 +426,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
+  digest = "1:249fd56fb36a223aee164e2dc35e3b3a1b92dd3873dfb60216280b9fb9d4a784"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "d442b75600c5d6484576502b3c53a55c54311be9"
+  revision = "15dcb6c0061f497a3f66e3ea034b629c6dd4d99e"
 
 [[projects]]
   digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  version = "=0.4.4"
+  branch = "fix-proxy"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"

--- a/application.yml
+++ b/application.yml
@@ -3,6 +3,7 @@ app:
   url: http://10.0.2.2
   username: admin
   password: admin
+  max_parallel_requests: 20
 server:
   port: 8081
   request_timeout: 4000ms

--- a/application.yml
+++ b/application.yml
@@ -3,7 +3,7 @@ app:
   url: http://10.0.2.2
   username: admin
   password: admin
-  max_parallel_requests: 20
+  max_parallel_requests: 5
 server:
   port: 8081
   request_timeout: 4000ms

--- a/cf/cf_suite_test.go
+++ b/cf/cf_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCf(t *testing.T) {
+func TestCF(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Service Manager Proxy CF Client Suite")
+	RunSpecs(t, "Service Broker Proxy CF Client Suite")
 }

--- a/cf/client.go
+++ b/cf/client.go
@@ -16,10 +16,8 @@ type CloudFoundryErr cfclient.CloudFoundryError
 // PlatformClient provides an implementation of the service-broker-proxy/pkg/cf/Client interface.
 // It is used to call into the cf that the proxy deployed at.
 type PlatformClient struct {
-	*cfclient.Client
-
-	reg                 *reconcile.Settings
-	maxParallelRequests int
+	client   cfclient.CloudFoundryClient
+	settings *reconcile.Settings
 }
 
 // Broker returns platform client which can perform platform broker operations
@@ -42,15 +40,14 @@ func NewClient(config *Settings) (*PlatformClient, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-	cfClient, err := config.Cf.CfClientCreateFunc(config.Cf.Config)
+	cfClient, err := config.CF.CfClientCreateFunc(config.CF.Config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PlatformClient{
-		Client:              cfClient,
-		reg:                 config.Reg,
-		maxParallelRequests: config.Reconcile.MaxParallelRequests,
+		client:   cfClient,
+		settings: config.Settings.Reconcile,
 	}, nil
 }
 

--- a/cf/client.go
+++ b/cf/client.go
@@ -17,7 +17,9 @@ type CloudFoundryErr cfclient.CloudFoundryError
 // It is used to call into the cf that the proxy deployed at.
 type PlatformClient struct {
 	*cfclient.Client
-	reg *reconcile.Settings
+
+	reg                 *reconcile.Settings
+	maxParallelRequests int
 }
 
 // Broker returns platform client which can perform platform broker operations
@@ -46,8 +48,9 @@ func NewClient(config *Settings) (*PlatformClient, error) {
 	}
 
 	return &PlatformClient{
-		Client: cfClient,
-		reg:    config.Reg,
+		Client:              cfClient,
+		reg:                 config.Reg,
+		maxParallelRequests: config.Reconcile.MaxParallelRequests,
 	}, nil
 }
 

--- a/cf/config.go
+++ b/cf/config.go
@@ -3,8 +3,10 @@ package cf
 
 import (
 	"fmt"
-	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"time"
+
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy"
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	"errors"
 
@@ -21,6 +23,8 @@ type ClientConfiguration struct {
 
 // Settings type wraps the CF client configuration
 type Settings struct {
+	sbproxy.Settings `mapstructure:",squash"`
+
 	Cf  *ClientConfiguration
 	Reg *reconcile.Settings `mapstructure:"app"`
 }
@@ -74,7 +78,11 @@ func (c *ClientConfiguration) Validate() error {
 
 // NewConfig creates ClientConfiguration from the provided environment
 func NewConfig(env env.Environment) (*Settings, error) {
-	cfSettings := &Settings{Cf: DefaultClientConfiguration(), Reg: &reconcile.Settings{}}
+	cfSettings := &Settings{
+		Settings: *sbproxy.DefaultSettings(),
+		Cf:       DefaultClientConfiguration(),
+		Reg:      &reconcile.Settings{},
+	}
 
 	if err := env.Unmarshal(cfSettings); err != nil {
 		return nil, err

--- a/cf/fetch_catalog_test.go
+++ b/cf/fetch_catalog_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Client FetchCatalog", func() {
 		expectedRequest = &cfclient.UpdateServiceBrokerRequest{
 			Name:      testBroker.Name,
 			BrokerURL: testBroker.BrokerURL,
-			Username:  settings.Reg.Username,
-			Password:  settings.Reg.Password,
+			Username:  settings.Reconcile.Username,
+			Password:  settings.Reconcile.Password,
 		}
 
 		ccServer.AppendHandlers(
@@ -57,6 +57,10 @@ var _ = Describe("Client FetchCatalog", func() {
 
 	AfterEach(func() {
 		ccServer.Close()
+	})
+
+	It("is not nil", func() {
+		Expect(client.CatalogFetcher()).ToNot(BeNil())
 	})
 
 	Describe("Fetch", func() {
@@ -102,5 +106,4 @@ var _ = Describe("Client FetchCatalog", func() {
 			})
 		})
 	})
-
 })

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -80,7 +80,7 @@ func (pc *PlatformClient) updateOrgVisibilityForPlan(ctx context.Context, plan c
 		log.C(ctx).Info("Plan with GUID = %s and NAME = %s is already public and therefore attempt to update access "+
 			"visibility for org with GUID = %s will be ignored", plan.Guid, plan.Name, orgGUID)
 	case isEnabled:
-		if _, err := pc.CreateServicePlanVisibility(plan.Guid, orgGUID); err != nil {
+		if _, err := pc.client.CreateServicePlanVisibility(plan.Guid, orgGUID); err != nil {
 			return wrapCFError(err)
 		}
 	case !isEnabled:
@@ -109,13 +109,13 @@ func (pc *PlatformClient) updatePlan(plan cfclient.ServicePlan, isPublic bool) e
 }
 
 func (pc *PlatformClient) deleteAccessVisibilities(query url.Values) error {
-	servicePlanVisibilities, err := pc.ListServicePlanVisibilitiesByQuery(query)
+	servicePlanVisibilities, err := pc.client.ListServicePlanVisibilitiesByQuery(query)
 	if err != nil {
 		return wrapCFError(err)
 	}
 
 	for _, visibility := range servicePlanVisibilities {
-		if err := pc.DeleteServicePlanVisibility(visibility.Guid, false); err != nil {
+		if err := pc.client.DeleteServicePlanVisibility(visibility.Guid, false); err != nil {
 			return wrapCFError(err)
 		}
 	}
@@ -131,9 +131,9 @@ func (pc *PlatformClient) UpdateServicePlan(planGUID string, request ServicePlan
 		return cfclient.ServicePlan{}, wrapCFError(err)
 	}
 
-	req := pc.NewRequestWithBody(http.MethodPut, "/v2/service_plans/"+planGUID, buf)
+	req := pc.client.NewRequestWithBody(http.MethodPut, "/v2/service_plans/"+planGUID, buf)
 
-	response, err := pc.DoRequest(req)
+	response, err := pc.client.DoRequest(req)
 	if err != nil {
 		return cfclient.ServicePlan{}, wrapCFError(err)
 	}

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -9,15 +9,15 @@ import (
 
 // GetBrokers implements service-broker-proxy/pkg/cf/Client.GetBrokers and provides logic for
 // obtaining the brokers that are already registered in CF
-func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]platform.ServiceBroker, error) {
-	brokers, err := pc.ListServiceBrokers()
+func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBroker, error) {
+	brokers, err := pc.client.ListServiceBrokers()
 	if err != nil {
 		return nil, wrapCFError(err)
 	}
 
-	var clientBrokers []platform.ServiceBroker
+	var clientBrokers []*platform.ServiceBroker
 	for _, broker := range brokers {
-		serviceBroker := platform.ServiceBroker{
+		serviceBroker := &platform.ServiceBroker{
 			GUID:      broker.Guid,
 			Name:      broker.Name,
 			BrokerURL: broker.BrokerURL,
@@ -31,7 +31,7 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]platform.ServiceBro
 // GetBrokerByName implements service-broker-proxy/pkg/cf/Client.GetBrokerByName and provides logic for getting a broker by name
 // that is already registered in CF
 func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*platform.ServiceBroker, error) {
-	broker, err := pc.GetServiceBrokerByName(name)
+	broker, err := pc.client.GetServiceBrokerByName(name)
 	if err != nil {
 		return nil, wrapCFError(err)
 	}
@@ -48,13 +48,13 @@ func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*pl
 func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateServiceBrokerRequest) (*platform.ServiceBroker, error) {
 
 	request := cfclient.CreateServiceBrokerRequest{
-		Username:  pc.reg.Username,
-		Password:  pc.reg.Password,
+		Username:  pc.settings.Username,
+		Password:  pc.settings.Password,
 		Name:      r.Name,
 		BrokerURL: r.BrokerURL,
 	}
 
-	broker, err := pc.CreateServiceBroker(request)
+	broker, err := pc.client.CreateServiceBroker(request)
 	if err != nil {
 		return nil, wrapCFError(err)
 	}
@@ -72,7 +72,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 // registering a new broker in CF
 func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteServiceBrokerRequest) error {
 
-	if err := pc.DeleteServiceBroker(r.GUID); err != nil {
+	if err := pc.client.DeleteServiceBroker(r.GUID); err != nil {
 		return wrapCFError(err)
 	}
 
@@ -84,13 +84,13 @@ func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteSe
 func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
 
 	request := cfclient.UpdateServiceBrokerRequest{
-		Username:  pc.reg.Username,
-		Password:  pc.reg.Password,
+		Username:  pc.settings.Username,
+		Password:  pc.settings.Password,
 		Name:      r.Name,
 		BrokerURL: r.BrokerURL,
 	}
 
-	broker, err := pc.UpdateServiceBroker(r.GUID, request)
+	broker, err := pc.client.UpdateServiceBroker(r.GUID, request)
 	if err != nil {
 		return nil, wrapCFError(err)
 	}

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/cloudfoundry-community/go-cfclient"
 )
 
 // GetBrokers implements service-broker-proxy/pkg/cf/Client.GetBrokers and provides logic for

--- a/cf/service_broker_test.go
+++ b/cf/service_broker_test.go
@@ -25,10 +25,10 @@ var _ = Describe("Client ServiceBroker", func() {
 		ctx             context.Context
 	)
 
-	assertBrokersFoundMatchTestBroker := func(expectedCount int, actualBrokers ...platform.ServiceBroker) {
+	assertBrokersFoundMatchTestBroker := func(expectedCount int, actualBrokers ...*platform.ServiceBroker) {
 		Expect(actualBrokers).To(HaveLen(expectedCount))
 		for _, b := range actualBrokers {
-			Expect(&b).To(Equal(testBroker))
+			Expect(b).To(Equal(testBroker))
 		}
 	}
 
@@ -49,6 +49,10 @@ var _ = Describe("Client ServiceBroker", func() {
 
 	AfterEach(func() {
 		ccServer.Close()
+	})
+
+	It("is not nil", func() {
+		Expect(client.Broker()).ToNot(BeNil())
 	})
 
 	Describe("GetBrokers", func() {
@@ -113,7 +117,7 @@ var _ = Describe("Client ServiceBroker", func() {
 							Entity: cfclient.ServiceBroker{
 								Name:      testBroker.Name,
 								BrokerURL: testBroker.BrokerURL,
-								Username:  settings.Reg.Username,
+								Username:  settings.Reconcile.Username,
 							},
 						},
 					},
@@ -193,7 +197,7 @@ var _ = Describe("Client ServiceBroker", func() {
 							Entity: cfclient.ServiceBroker{
 								Name:      brokerName,
 								BrokerURL: testBroker.BrokerURL,
-								Username:  settings.Reg.Username,
+								Username:  settings.Reconcile.Username,
 							},
 						},
 					},
@@ -205,7 +209,7 @@ var _ = Describe("Client ServiceBroker", func() {
 				broker, err := client.GetBrokerByName(ctx, brokerName)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				assertBrokersFoundMatchTestBroker(1, *broker)
+				assertBrokersFoundMatchTestBroker(1, broker)
 			})
 		})
 
@@ -218,8 +222,8 @@ var _ = Describe("Client ServiceBroker", func() {
 			expectedRequest = &cfclient.CreateServiceBrokerRequest{
 				Name:      testBroker.Name,
 				BrokerURL: testBroker.BrokerURL,
-				Username:  settings.Reg.Username,
-				Password:  settings.Reg.Password,
+				Username:  settings.Reconcile.Username,
+				Password:  settings.Reconcile.Password,
 			}
 
 			actualRequest = &platform.CreateServiceBrokerRequest{
@@ -265,7 +269,7 @@ var _ = Describe("Client ServiceBroker", func() {
 					Entity: cfclient.ServiceBroker{
 						Name:      testBroker.Name,
 						BrokerURL: testBroker.BrokerURL,
-						Username:  settings.Reg.Username,
+						Username:  settings.Reconcile.Username,
 					},
 				}
 			})
@@ -338,8 +342,8 @@ var _ = Describe("Client ServiceBroker", func() {
 			expectedRequest = &cfclient.UpdateServiceBrokerRequest{
 				Name:      testBroker.Name,
 				BrokerURL: testBroker.BrokerURL,
-				Username:  settings.Reg.Username,
-				Password:  settings.Reg.Password,
+				Username:  settings.Reconcile.Username,
+				Password:  settings.Reconcile.Password,
 			}
 
 			actualRequest = &platform.UpdateServiceBrokerRequest{

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -175,7 +175,7 @@ func (pc *PlatformClient) getServicesByBrokers(ctx context.Context, brokers []cf
 		wg.Add(1)
 		go func(chunk []cfclient.ServiceBroker) {
 			defer func() {
-				//<-wgLimitChannel
+				<-wgLimitChannel
 				wg.Done()
 			}()
 			brokerGUIDs := make([]string, 0, len(chunk))

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -126,7 +126,6 @@ func (pc *PlatformClient) getBrokersByName(ctx context.Context, names []string) 
 		case <-ctx.Done():
 			return nil, errors.WithStack(ctx.Err())
 		case wgLimitChannel <- struct{}{}:
-			break
 		}
 		wg.Add(1)
 		go func(chunk []string) {
@@ -172,7 +171,6 @@ func (pc *PlatformClient) getServicesByBrokers(ctx context.Context, brokers []cf
 		case <-ctx.Done():
 			return nil, errors.WithStack(ctx.Err())
 		case wgLimitChannel <- struct{}{}:
-			break
 		}
 		wg.Add(1)
 		go func(chunk []cfclient.ServiceBroker) {
@@ -224,7 +222,6 @@ func (pc *PlatformClient) getPlansByServices(ctx context.Context, services []cfc
 		case <-ctx.Done():
 			return nil, errors.WithStack(ctx.Err())
 		case wgLimitChannel <- struct{}{}:
-			break
 		}
 		wg.Add(1)
 		go func(chunk []cfclient.Service) {
@@ -276,7 +273,6 @@ func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, plans []cfcl
 		case <-ctx.Done():
 			return nil, errors.WithStack(ctx.Err())
 		case wgLimitChannel <- struct{}{}:
-			break
 		}
 		wg.Add(1)
 		go func(chunk []cfclient.ServicePlan) {

--- a/main.go
+++ b/main.go
@@ -24,22 +24,20 @@ func main() {
 		panic(fmt.Errorf("error setting CF environment values: %s", err))
 	}
 
-	platformConfig, err := cf.NewConfig(env)
+	proxySettings, err := cf.NewConfig(env)
 	if err != nil {
 		panic(fmt.Errorf("error loading config: %s", err))
 	}
 
-	platformClient, err := cf.NewClient(platformConfig)
+	platformClient, err := cf.NewClient(proxySettings)
 	if err != nil {
 		panic(fmt.Errorf("error creating CF client: %s", err))
 	}
-	settings, err := sbproxy.NewSettings(env)
-	if err != nil {
-		panic(fmt.Errorf("error creating settings from environment: %s", err))
-	}
-	proxyBuilder, err := sbproxy.New(ctx, cancel, settings, platformClient)
+
+	proxyBuilder, err := sbproxy.New(ctx, cancel, &proxySettings.Settings, platformClient)
 	if err != nil {
 		panic(fmt.Errorf("error creating sbproxy: %s", err))
 	}
+
 	proxyBuilder.Build().Run()
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ applications:
       GOPACKAGENAME: github.com/Peripli/service-broker-proxy-cf
       APP_USERNAME: admin
       APP_PASSWORD: admin
+      APP_MAX_PARALLEL_REQUESTS: 20
       SM_URL: https://smanager.local.pcfdev.io
       SM_OSB_API_PATH: /v1/osb
       SM_SKIP_SSL_VALIDATION: false


### PR DESCRIPTION
Currently there is no limit in the go routines spawned during fetching brokers, plans, visibilities, etc from CC which may eventually result in crashing the Cloud Controller (DoS) or crashing the proxy process (OOM).

This PR addresses the issue by adding a limit to the maximum number of spawned go routines during fetching stuff from CC.