### PR TITLE
Use platform credentials for broker registrations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,8 +18,8 @@
   version = "v1.4.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5de1859f1846f0d09a68846f5fa1be8ec4401e411fb397699d870b778f33932e"
+  branch = "migrate-url"
+  digest = "1:e7e92714f67c2789a76ef9ebdb3c92fd3e27510e3bc5a30a1f3a3dcc5c089204"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/filter",
@@ -32,7 +32,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "6c4c24e19c9c3feefd2a4f82a3ee73a4017d3030"
+  revision = "53deeb7c4318a2849dfff52eae72c3f8bc64a088"
 
 [[projects]]
   digest = "1:7a122bb0965a9f0f3b4f9a6a0a5c154602cf4a8847cfea7b256ebf5af30e3d88"
@@ -410,7 +410,7 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "3f473d35a33aa6fdd203e306dc439b797820e3f1"
+  revision = "d28f0bde5980168871434b95cfc858db9f2a7a99"
 
 [[projects]]
   branch = "master"
@@ -430,7 +430,7 @@
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "93c9922d18aeb82498a065f07aec7ad7fa60dfb7"
+  revision = "d442b75600c5d6484576502b3c53a55c54311be9"
 
 [[projects]]
   digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  branch = "master"
+  branch = "migrate-url"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"

--- a/cf/config.go
+++ b/cf/config.go
@@ -81,13 +81,8 @@ func NewConfig(env env.Environment, settings *sbproxy.Settings) (*Settings, erro
 		return nil, err
 	}
 
-	if len(cfSettings.Reg.Username) == 0 {
-		cfSettings.Reg.Username = settings.Sm.User
-	}
-
-	if len(cfSettings.Reg.Password) == 0 {
-		cfSettings.Reg.Password = settings.Sm.Password
-	}
+	cfSettings.Reg.Username = settings.Sm.User
+	cfSettings.Reg.Password = settings.Sm.Password
 
 	return cfSettings, nil
 }

--- a/cf/config.go
+++ b/cf/config.go
@@ -3,6 +3,7 @@ package cf
 
 import (
 	"fmt"
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy"
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"time"
 
@@ -73,12 +74,15 @@ func (c *ClientConfiguration) Validate() error {
 }
 
 // NewConfig creates ClientConfiguration from the provided environment
-func NewConfig(env env.Environment) (*Settings, error) {
+func NewConfig(env env.Environment, settings *sbproxy.Settings) (*Settings, error) {
 	cfSettings := &Settings{Cf: DefaultClientConfiguration(), Reg: &reconcile.Settings{}}
 
 	if err := env.Unmarshal(cfSettings); err != nil {
 		return nil, err
 	}
+
+	cfSettings.Reg.Username = settings.Sm.User
+	cfSettings.Reg.Password = settings.Sm.Password
 
 	return cfSettings, nil
 }

--- a/cf/config.go
+++ b/cf/config.go
@@ -81,8 +81,13 @@ func NewConfig(env env.Environment, settings *sbproxy.Settings) (*Settings, erro
 		return nil, err
 	}
 
-	cfSettings.Reg.Username = settings.Sm.User
-	cfSettings.Reg.Password = settings.Sm.Password
+	if len(cfSettings.Reg.Username) == 0 {
+		cfSettings.Reg.Username = settings.Sm.User
+	}
+
+	if len(cfSettings.Reg.Password) == 0 {
+		cfSettings.Reg.Password = settings.Sm.Password
+	}
 
 	return cfSettings, nil
 }

--- a/cf/config_test.go
+++ b/cf/config_test.go
@@ -1,7 +1,9 @@
 package cf_test
 
 import (
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy"
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
+	"github.com/Peripli/service-broker-proxy/pkg/sm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -82,10 +84,11 @@ var _ = Describe("Config", func() {
 		var (
 			fakeEnv       *envfakes.FakeEnvironment
 			creationError = fmt.Errorf("creation error")
+			proxySettings = &sbproxy.Settings{Sm: &sm.Settings{}}
 		)
 
 		assertErrorDuringNewConfiguration := func() {
-			_, err := cf.NewConfig(fakeEnv)
+			_, err := cf.NewConfig(fakeEnv, proxySettings)
 			Expect(err).Should(HaveOccurred())
 		}
 
@@ -150,7 +153,7 @@ var _ = Describe("Config", func() {
 				})
 
 				Specify("the environment values are used", func() {
-					c, err := cf.NewConfig(fakeEnv)
+					c, err := cf.NewConfig(fakeEnv, proxySettings)
 
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(fakeEnv.UnmarshalCallCount()).To(Equal(1))
@@ -171,7 +174,7 @@ var _ = Describe("Config", func() {
 				})
 
 				It("returns an empty config", func() {
-					c, err := cf.NewConfig(fakeEnv)
+					c, err := cf.NewConfig(fakeEnv, proxySettings)
 					Expect(err).To(Not(HaveOccurred()))
 
 					Expect(fakeEnv.UnmarshalCallCount()).To(Equal(1))

--- a/main.go
+++ b/main.go
@@ -24,7 +24,12 @@ func main() {
 		panic(fmt.Errorf("error setting CF environment values: %s", err))
 	}
 
-	platformConfig, err := cf.NewConfig(env)
+	proxyConfig, err := sbproxy.NewSettings(env)
+	if err != nil {
+		panic(fmt.Errorf("error creating proxy config from environment: %s", err))
+	}
+
+	platformConfig, err := cf.NewConfig(env, proxyConfig)
 	if err != nil {
 		panic(fmt.Errorf("error loading config: %s", err))
 	}
@@ -33,13 +38,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("error creating CF client: %s", err))
 	}
-	settings, err := sbproxy.NewSettings(env)
-	if err != nil {
-		panic(fmt.Errorf("error creating settings from environment: %s", err))
-	}
-	proxyBuilder, err := sbproxy.New(ctx, cancel, settings, platformClient)
+
+	proxyBuilder, err := sbproxy.New(ctx, cancel, proxyConfig, platformClient)
 	if err != nil {
 		panic(fmt.Errorf("error creating sbproxy: %s", err))
 	}
+
 	proxyBuilder.Build().Run()
 }


### PR DESCRIPTION
# Use platform credentials for broker registrations

## Motivation

https://github.com/Peripli/service-broker-proxy/pull/83

## Approach

Platform client's configuration has username and password. On bootstrap their values are replaced with the platform credentials.

## Progress

- [x] Use platform credentials instead of technical "app" credentials when registering proxy broker in platform

## Depends on: 

https://github.com/Peripli/service-broker-proxy/pull/83