### PR TITLE
Add caching for CF plans

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,7 +40,8 @@
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:1fb0b5cca8592ec0d9592af8d457dd0613b79f14fe8aec3a9dab7fc21a3bd51a"
+  branch = "caching-plan-resolver"
+  digest = "1:c48021d9c2bd37be3ea9ca9ae651487ded91ec7c362df3b71d07db66bb4afd8e"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/authn",
@@ -53,8 +54,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "a2592f2e5e371fbe00c877ee8c3476a1c75f7c0d"
-  version = "v0.8.0"
+  revision = "b2597b76d455d69b4221476270ed06a75b242901"
 
 [[projects]]
   digest = "1:055fc0e43add62718304665b638fa52b0ddc2aa61873f6fdf1bc047d84283aa5"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,7 +40,8 @@
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:730f54e849a61172924eaa5a12892732000fef4946dfd79997d1a7a7dc6f2ea5"
+  branch = "caching-plan-resolver"
+  digest = "1:6302d364698f967375f8972b884e3f51b9eae860c1588a620abe3edc86e4a28a"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/authn",
@@ -53,8 +54,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "6c72e7925bb9760cfe1fa10c0315e51e81301005"
-  version = "v0.8.1"
+  revision = "e4168a330a0671b76172927c8729aa30f98653fa"
 
 [[projects]]
   digest = "1:42a542d1f078682ca31f70ae14671f32b605269c01210225fd9361f7da7a9dda"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,8 +40,8 @@
   version = "v1.5.0"
 
 [[projects]]
-  branch = "caching-plan-resolver"
-  digest = "1:6302d364698f967375f8972b884e3f51b9eae860c1588a620abe3edc86e4a28a"
+  branch = "master"
+  digest = "1:f70e80c595cce0d596ce1e4d9f2701f08d40ebca41fe1d2a7a1333acad062a63"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/authn",
@@ -54,7 +54,7 @@
     "pkg/sm",
   ]
   pruneopts = "UT"
-  revision = "e4168a330a0671b76172927c8729aa30f98653fa"
+  revision = "0e6b6a528c8b8ce4f86bb58d7242f4329444e93e"
 
 [[projects]]
   digest = "1:42a542d1f078682ca31f70ae14671f32b605269c01210225fd9361f7da7a9dda"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  version = "=0.8.0"
+  branch = "caching-plan-resolver"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  branch = "caching-plan-resolver"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  version = "=0.8.1"
+  branch = "caching-plan-resolver"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"

--- a/cf/cache.go
+++ b/cf/cache.go
@@ -1,0 +1,76 @@
+package cf
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+
+	"github.com/Peripli/service-manager/pkg/log"
+)
+
+// ResetCache reloads all the data from CF
+func (pc *PlatformClient) ResetCache(ctx context.Context) error {
+	logger := log.C(ctx)
+
+	query := url.Values{
+		cfPageSizeParam: []string{strconv.Itoa(pc.settings.CF.PageSize)},
+	}
+
+	logger.Info("Loading all service brokers from Cloud Foundry...")
+	brokers, err := pc.client.ListServiceBrokersByQuery(query)
+	if err != nil {
+		return wrapCFError(err)
+	}
+	logger.Infof("Loaded %d service brokers from Cloud Foundry", len(brokers))
+
+	logger.Info("Loading all services from Cloud Foundry...")
+	services, err := pc.client.ListServicesByQuery(query)
+	if err != nil {
+		return wrapCFError(err)
+	}
+	logger.Infof("Loaded %d services from Cloud Foundry", len(services))
+
+	logger.Info("Loading all service plans from Cloud Foundry...")
+	plans, err := pc.client.ListServicePlansByQuery(query)
+	if err != nil {
+		return wrapCFError(err)
+	}
+	logger.Infof("Loaded %d service plans from Cloud Foundry...", len(plans))
+
+	pc.planResolver.Reset(brokers, services, plans)
+
+	return nil
+}
+
+func (pc *PlatformClient) reloadBroker(ctx context.Context, brokerGUID string) error {
+	logger := log.C(ctx)
+
+	logger.Infof("Loading service broker with GUID %s from Cloud Foundry...", brokerGUID)
+	broker, err := pc.client.GetServiceBrokerByGuid(brokerGUID)
+	if err != nil {
+		return wrapCFError(err)
+	}
+
+	logger.Infof("Loading services of broker with GUID %s from Cloud Foundry...", brokerGUID)
+	services, err := pc.client.ListServicesByQuery(
+		pc.buildQuery("service_broker_guid", brokerGUID))
+	if err != nil {
+		return wrapCFError(err)
+	}
+
+	serviceGUIDs := make([]string, len(services))
+	for i := range services {
+		serviceGUIDs[i] = services[i].Guid
+	}
+	logger.Infof("Loading plans of services with GUIDs %v from Cloud Foundry...", serviceGUIDs)
+	plans, err := pc.client.ListServicePlansByQuery(
+		pc.buildQuery("service_guid", serviceGUIDs...))
+	if err != nil {
+		return wrapCFError(err)
+	}
+	logger.Infof("Loaded %d plans from Cloud Foundry", len(plans))
+
+	pc.planResolver.ResetBroker(broker, services, plans)
+
+	return nil
+}

--- a/cf/cache_test.go
+++ b/cf/cache_test.go
@@ -1,0 +1,313 @@
+package cf_test
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/Peripli/service-broker-proxy-cf/cf"
+	"github.com/Peripli/service-broker-proxy/pkg/platform"
+	"github.com/Peripli/service-manager/pkg/log"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Cache", func() {
+
+	type brokerData struct {
+		broker   cfclient.ServiceBroker
+		services []cfclient.Service
+		plans    []cfclient.ServicePlan
+	}
+
+	var (
+		ctx      context.Context
+		err      error
+		ccServer *ghttp.Server
+		client   *cf.PlatformClient
+
+		brokersRequest, servicesRequest, plansRequest, visibilitiesRequest *http.Request
+
+		broker1, broker2 brokerData
+	)
+
+	recordRequest := func(r **http.Request) http.HandlerFunc {
+		*r = nil
+		return func(res http.ResponseWriter, req *http.Request) {
+			*r = req
+		}
+	}
+
+	setupCCRoutes := func(brokers ...brokerData) {
+		brokersResponse := cfclient.ServiceBrokerResponse{Pages: 1}
+		servicesResponse := cfclient.ServicesResponse{Pages: 1}
+		plansResponse := cfclient.ServicePlansResponse{Pages: 1}
+
+		for _, broker := range brokers {
+			brokersResponse.Resources = append(brokersResponse.Resources, cfclient.ServiceBrokerResource{
+				Meta: cfclient.Meta{
+					Guid: broker.broker.Guid,
+				},
+				Entity: broker.broker,
+			})
+			for _, service := range broker.services {
+				servicesResponse.Resources = append(servicesResponse.Resources, cfclient.ServicesResource{
+					Meta: cfclient.Meta{
+						Guid: service.Guid,
+					},
+					Entity: service,
+				})
+				for _, plan := range broker.plans {
+					plansResponse.Resources = append(plansResponse.Resources, cfclient.ServicePlanResource{
+						Meta: cfclient.Meta{
+							Guid: plan.Guid,
+						},
+						Entity: plan,
+					})
+				}
+			}
+		}
+
+		brokersResponse.Count = len(brokersResponse.Resources)
+		servicesResponse.Count = len(servicesResponse.Resources)
+		plansResponse.Count = len(plansResponse.Resources)
+
+		ccServer.RouteToHandler(http.MethodGet, "/v2/service_brokers",
+			ghttp.CombineHandlers(
+				recordRequest(&brokersRequest),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, brokersResponse),
+			),
+		)
+		ccServer.RouteToHandler(http.MethodGet, "/v2/services",
+			ghttp.CombineHandlers(
+				recordRequest(&servicesRequest),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, servicesResponse),
+			),
+		)
+		ccServer.RouteToHandler(http.MethodGet, "/v2/service_plans",
+			ghttp.CombineHandlers(
+				recordRequest(&plansRequest),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, plansResponse),
+			),
+		)
+		ccServer.RouteToHandler(http.MethodGet, "/v2/service_plan_visibilities",
+			ghttp.CombineHandlers(
+				recordRequest(&visibilitiesRequest),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, cfclient.ServicePlanVisibilitiesResponse{
+					Count: 0,
+					Pages: 0,
+				}),
+			),
+		)
+	}
+
+	getRequestGUIDS := func(req *http.Request, param string) []string {
+		if req == nil {
+			return nil
+		}
+		query := req.URL.Query().Get("q")
+		pattern := param + ` IN (.*)`
+		ExpectWithOffset(1, query).To(MatchRegexp(pattern), req.RequestURI)
+		matches := regexp.MustCompile(pattern).FindStringSubmatch(query)
+		ExpectWithOffset(1, matches).To(HaveLen(2), req.RequestURI)
+		return strings.Split(matches[1], ",")
+	}
+
+	getPlanGUIDS := func() []string {
+		client.GetVisibilitiesByBrokers(ctx, []string{"broker1", "broker2"})
+		return getRequestGUIDS(visibilitiesRequest, "service_plan_guid")
+	}
+
+	clearRequests := func() {
+		brokersRequest = nil
+		servicesRequest = nil
+		plansRequest = nil
+		visibilitiesRequest = nil
+	}
+
+	BeforeEach(func() {
+		broker1 = brokerData{
+			broker: cfclient.ServiceBroker{
+				Guid: "broker1-guid",
+				Name: "broker1",
+			},
+			services: []cfclient.Service{
+				{
+					Guid:              "broker1-service1-guid",
+					ServiceBrokerGuid: "broker1-guid",
+				},
+				{
+					Guid:              "broker1-service2-guid",
+					ServiceBrokerGuid: "broker1-guid",
+				},
+			},
+			plans: []cfclient.ServicePlan{
+				{
+					Guid:        "broker1-service1-plan1-guid",
+					Name:        "broker1-service1-plan1",
+					ServiceGuid: "broker1-service1-guid",
+				},
+				{
+					Guid:        "broker1-service2-plan1-guid",
+					Name:        "broker1-service2-plan1",
+					ServiceGuid: "broker1-service2-guid",
+				},
+			},
+		}
+		broker2 = brokerData{
+			broker: cfclient.ServiceBroker{
+				Guid: "broker2-guid",
+				Name: "broker2",
+			},
+			services: []cfclient.Service{
+				{
+					Guid:              "broker2-service1-guid",
+					ServiceBrokerGuid: "broker2-guid",
+				},
+			},
+			plans: []cfclient.ServicePlan{
+				{
+					Guid:        "broker2-service1-plan1-guid",
+					Name:        "broker2-service1-plan1",
+					ServiceGuid: "broker2-service1-guid",
+				},
+				{
+					Guid:        "broker2-service1-plan2-guid",
+					Name:        "broker2-service1-plan2",
+					ServiceGuid: "broker2-service1-guid",
+				},
+			},
+		}
+
+		ctx, err = log.Configure(context.Background(), &log.Settings{
+			Level:  "debug",
+			Format: "text",
+			Output: "ginkgowriter",
+		})
+		Expect(err).To(BeNil())
+
+		ccServer = fakeCCServer(true)
+		_, client = ccClient(ccServer.URL())
+		setupCCRoutes()
+	})
+
+	AfterEach(func() {
+		ccServer.Close()
+	})
+
+	Describe("ResetCache", func() {
+		It("loads all service plans from CF", func() {
+			setupCCRoutes(broker1, broker2)
+
+			Expect(client.ResetCache(ctx)).To(Succeed())
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service2-plan1-guid",
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+		})
+
+		It("replaces old service plans", func() {
+			setupCCRoutes(broker1)
+			Expect(client.ResetCache(ctx)).To(Succeed())
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service2-plan1-guid",
+			}))
+
+			setupCCRoutes(broker2)
+			Expect(client.ResetCache(ctx)).To(Succeed())
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+		})
+	})
+
+	Describe("ResetBroker", func() {
+		It("loads the plans of the given broker", func() {
+			setupCCRoutes(broker1)
+			Expect(getPlanGUIDS()).To(BeEmpty())
+
+			broker := platform.ServiceBroker{Name: "broker1", GUID: "broker1-guid"}
+			Expect(client.ResetBroker(ctx, &broker, false)).To(Succeed())
+
+			Expect(brokersRequest).To(BeNil())
+			Expect(getRequestGUIDS(servicesRequest, "broker_guid")).
+				To(ConsistOf([]string{"broker1-guid"}))
+			Expect(getRequestGUIDS(plansRequest, "service_guid")).
+				To(ConsistOf([]string{"broker1-service1-guid", "broker1-service2-guid"}))
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service2-plan1-guid",
+			}))
+		})
+
+		It("removes the plans of the given broker", func() {
+			setupCCRoutes(broker1, broker2)
+
+			Expect(client.ResetCache(ctx)).To(Succeed())
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service2-plan1-guid",
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+
+			clearRequests()
+			broker := platform.ServiceBroker{Name: "broker1", GUID: "broker1-guid"}
+			Expect(client.ResetBroker(ctx, &broker, true)).To(Succeed())
+			Expect(brokersRequest).To(BeNil())
+			Expect(servicesRequest).To(BeNil())
+			Expect(plansRequest).To(BeNil())
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+		})
+
+		It("replaces the plans of the given broker", func() {
+			setupCCRoutes(broker1, broker2)
+
+			Expect(client.ResetCache(ctx)).To(Succeed())
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service2-plan1-guid",
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+
+			broker1.plans = append(broker1.plans, cfclient.ServicePlan{
+				Guid:        "broker1-service1-plan9-guid",
+				Name:        "broker1-service1-plan9",
+				ServiceGuid: "broker1-service1-guid",
+			})
+			setupCCRoutes(broker1)
+			broker := platform.ServiceBroker{Name: "broker1", GUID: "broker1-guid"}
+			Expect(client.ResetBroker(ctx, &broker, false)).To(Succeed())
+			Expect(brokersRequest).To(BeNil())
+			Expect(getRequestGUIDS(servicesRequest, "broker_guid")).
+				To(ConsistOf([]string{"broker1-guid"}))
+			Expect(getRequestGUIDS(plansRequest, "service_guid")).
+				To(ConsistOf([]string{"broker1-service1-guid", "broker1-service2-guid"}))
+
+			Expect(getPlanGUIDS()).To(ConsistOf([]string{
+				"broker1-service1-plan1-guid",
+				"broker1-service1-plan9-guid",
+				"broker1-service2-plan1-guid",
+				"broker2-service1-plan1-guid",
+				"broker2-service1-plan2-guid",
+			}))
+		})
+
+	})
+})

--- a/cf/cfmodel/plan_resolver.go
+++ b/cf/cfmodel/plan_resolver.go
@@ -1,0 +1,179 @@
+package cfmodel
+
+import "github.com/cloudfoundry-community/go-cfclient"
+
+import "sync"
+
+// PlanData contains selected properties of a service plan in CF
+type PlanData struct {
+	BrokerName    string
+	CatalogPlanID string
+	Public        bool
+}
+
+// PlanMap maps CF plan id to PlanData
+type PlanMap map[string]PlanData
+
+type planNode = cfclient.ServicePlan
+
+type serviceNode struct {
+	cfclient.Service
+	plans []*planNode
+}
+
+type brokerNode struct {
+	cfclient.ServiceBroker
+	services []*serviceNode
+}
+
+// PlanResolver provides functions for locating service plans based on data loaded from CF
+// It just stores the data and provides querying in a thread-safe way
+// It does not perform any data fetching
+// Currently PlanResolver is used in setting visibilities during both resync and notification processing
+type PlanResolver struct {
+	mutex sync.RWMutex
+
+	brokers  map[string]*brokerNode
+	services map[string]*serviceNode
+	plans    map[string]*planNode
+
+	brokerNameMap map[string]*brokerNode
+}
+
+// NewPlanResolver constructs a new NewPlanResolver
+func NewPlanResolver() *PlanResolver {
+	return &PlanResolver{
+		brokers:       map[string]*brokerNode{},
+		services:      map[string]*serviceNode{},
+		plans:         map[string]*planNode{},
+		brokerNameMap: map[string]*brokerNode{},
+	}
+}
+
+func (r *PlanResolver) addBrokers(brokers ...cfclient.ServiceBroker) {
+	for _, broker := range brokers {
+		bnode := &brokerNode{ServiceBroker: broker}
+		r.brokers[broker.Guid] = bnode
+		r.brokerNameMap[broker.Name] = bnode
+	}
+}
+
+func (r *PlanResolver) addServices(services ...cfclient.Service) {
+	for _, service := range services {
+		snode := &serviceNode{Service: service}
+		r.services[service.Guid] = snode
+		if broker, found := r.brokers[service.ServiceBrokerGuid]; found {
+			broker.services = append(broker.services, snode)
+		}
+	}
+}
+
+func (r *PlanResolver) addPlans(plans ...cfclient.ServicePlan) {
+	for _, plan := range plans {
+		plan := plan // use a separate object with a separate address
+		r.plans[plan.Guid] = &plan
+		if service, found := r.services[plan.ServiceGuid]; found {
+			service.plans = append(service.plans, &plan)
+		}
+	}
+}
+
+// Reset replaces all the data
+func (r *PlanResolver) Reset(
+	brokers []cfclient.ServiceBroker,
+	services []cfclient.Service,
+	plans []cfclient.ServicePlan,
+) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.brokers = map[string]*brokerNode{}
+	r.services = map[string]*serviceNode{}
+	r.plans = map[string]*planNode{}
+	r.brokerNameMap = map[string]*brokerNode{}
+
+	r.addBrokers(brokers...)
+	r.addServices(services...)
+	r.addPlans(plans...)
+}
+
+// ResetBroker replaces the data for a particular broker
+func (r *PlanResolver) ResetBroker(
+	broker cfclient.ServiceBroker,
+	services []cfclient.Service,
+	plans []cfclient.ServicePlan,
+) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.deleteBroker(broker.Guid)
+
+	r.addBrokers(broker)
+	r.addServices(services...)
+	r.addPlans(plans...)
+}
+
+func (r *PlanResolver) deleteBroker(brokerGUID string) {
+	broker, ok := r.brokers[brokerGUID]
+	if !ok {
+		return
+	}
+	delete(r.brokers, brokerGUID)
+	delete(r.brokerNameMap, broker.Name)
+
+	for _, service := range broker.services {
+		delete(r.services, service.Guid)
+		for _, plan := range service.plans {
+			delete(r.plans, plan.Guid)
+		}
+	}
+}
+
+// DeleteBroker deletes the data for a particular broker
+func (r *PlanResolver) DeleteBroker(brokerGUID string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.deleteBroker(brokerGUID)
+}
+
+// GetPlan returns the plan with given catalog ID and broker name
+func (r *PlanResolver) GetPlan(catalogPlanID, brokerName string) *cfclient.ServicePlan {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	broker, found := r.brokerNameMap[brokerName]
+	if !found {
+		return nil
+	}
+	for _, service := range broker.services {
+		for _, plan := range service.plans {
+			if plan.UniqueId == catalogPlanID {
+				return plan
+			}
+		}
+	}
+	return nil
+}
+
+// GetBrokerPlans returns all the plans from brokers with given names
+func (r *PlanResolver) GetBrokerPlans(brokerNames []string) PlanMap {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	plans := PlanMap{}
+	for _, brokerName := range brokerNames {
+		if broker, found := r.brokerNameMap[brokerName]; found {
+			for _, service := range broker.services {
+				for _, plan := range service.plans {
+					plans[plan.Guid] = PlanData{
+						BrokerName:    brokerName,
+						CatalogPlanID: plan.UniqueId,
+						Public:        plan.Public,
+					}
+				}
+			}
+		}
+	}
+	return plans
+}

--- a/cf/cfmodel/plan_resolver_test.go
+++ b/cf/cfmodel/plan_resolver_test.go
@@ -1,6 +1,8 @@
 package cfmodel_test
 
 import (
+	"context"
+
 	"github.com/cloudfoundry-community/go-cfclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,29 +18,9 @@ var _ = Describe("PlanResolver", func() {
 		plans    []cfclient.ServicePlan
 	}
 
-	var (
-		broker1 = brokerData{
-			broker: cfclient.ServiceBroker{Guid: "b1-id", Name: "b1"},
-			services: []cfclient.Service{
-				{Guid: "b1-s1-id", Label: "b1-s1", ServiceBrokerGuid: "b1-id"},
-			},
-			plans: []cfclient.ServicePlan{
-				{Guid: "b1-s1-p1-id", Name: "b1-s1-p1", ServiceGuid: "b1-s1-id", UniqueId: "s1-p1-cid"},
-			},
-		}
-		broker2 = brokerData{
-			broker: cfclient.ServiceBroker{Guid: "b2-id", Name: "b2"},
-			services: []cfclient.Service{
-				{Guid: "b2-s1-id", Label: "b2-s1", ServiceBrokerGuid: "b2-id"},
-			},
-			plans: []cfclient.ServicePlan{
-				{Guid: "b2-s1-p1-id", Name: "b2-s1-p1", ServiceGuid: "b2-s1-id", UniqueId: "s1-p1-cid", Public: true},
-				{Guid: "b2-s1-p2-id", Name: "b2-s1-p2", ServiceGuid: "b2-s1-id", UniqueId: "s1-p2-cid"},
-			},
-		}
-	)
-
+	var broker1, broker2 brokerData
 	var resolver *cfmodel.PlanResolver
+	var ctx context.Context
 
 	resetResolver := func(brokers ...brokerData) {
 		var (
@@ -51,17 +33,40 @@ var _ = Describe("PlanResolver", func() {
 			allServices = append(allServices, b.services...)
 			allPlans = append(allPlans, b.plans...)
 		}
-		resolver.Reset(allBrokers, allServices, allPlans)
+		resolver.Reset(ctx, allBrokers, allServices, allPlans)
 	}
 
 	BeforeEach(func() {
+		broker1 = brokerData{
+			broker: cfclient.ServiceBroker{Guid: "b1-id", Name: "b1"},
+			services: []cfclient.Service{
+				{Guid: "b1-s1-id", Label: "b1-s1", ServiceBrokerGuid: "b1-id"},
+			},
+			plans: []cfclient.ServicePlan{
+				{Guid: "b1-s1-p1-id", Name: "b1-s1-p1", ServiceGuid: "b1-s1-id", UniqueId: "s1-p1-cid"},
+			},
+		}
+
+		broker2 = brokerData{
+			broker: cfclient.ServiceBroker{Guid: "b2-id", Name: "b2"},
+			services: []cfclient.Service{
+				{Guid: "b2-s1-id", Label: "b2-s1", ServiceBrokerGuid: "b2-id"},
+			},
+			plans: []cfclient.ServicePlan{
+				{Guid: "b2-s1-p1-id", Name: "b2-s1-p1", ServiceGuid: "b2-s1-id", UniqueId: "s1-p1-cid", Public: true},
+				{Guid: "b2-s1-p2-id", Name: "b2-s1-p2", ServiceGuid: "b2-s1-id", UniqueId: "s1-p2-cid"},
+			},
+		}
+
+		ctx = context.Background()
 		resolver = cfmodel.NewPlanResolver()
 	})
 
 	Describe("GetPlan", func() {
 		Context("Empty resolver", func() {
 			It("It returns no plan", func() {
-				Expect(resolver.GetPlan("catalog-id", "broker-name")).To(BeNil())
+				_, found := resolver.GetPlan("catalog-id", "broker-name")
+				Expect(found).To(BeFalse())
 			})
 		})
 
@@ -71,15 +76,19 @@ var _ = Describe("PlanResolver", func() {
 			})
 
 			It("returns the correct plan even if different brokers have plans with same catalog id", func() {
-				plan := resolver.GetPlan("s1-p1-cid", "b1")
-				Expect(plan.Guid).To(Equal("b1-s1-p1-id"))
-				plan = resolver.GetPlan("s1-p1-cid", "b2")
-				Expect(plan.Guid).To(Equal("b2-s1-p1-id"))
+				plan, _ := resolver.GetPlan("s1-p1-cid", "b1")
+				Expect(plan).To(Equal(cfmodel.PlanData{
+					GUID: "b1-s1-p1-id", BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false}))
+				plan, _ = resolver.GetPlan("s1-p1-cid", "b2")
+				Expect(plan).To(Equal(cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true}))
 			})
 
 			It("does not return a non-existing plan", func() {
-				Expect(resolver.GetPlan("s1-p1-cid", "broker-name")).To(BeNil())
-				Expect(resolver.GetPlan("catalog-id", "b1")).To(BeNil())
+				_, found := resolver.GetPlan("s1-p1-cid", "broker-name")
+				Expect(found).To(BeFalse())
+				_, found = resolver.GetPlan("catalog-id", "b1")
+				Expect(found).To(BeFalse())
 			})
 		})
 
@@ -99,21 +108,24 @@ var _ = Describe("PlanResolver", func() {
 
 			It("returns existing broker plans", func() {
 				plans := resolver.GetBrokerPlans([]string{"b2"})
-				Expect(plans).To(HaveKeyWithValue("b2-s1-p1-id", cfmodel.PlanData{
-					BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true}))
-				Expect(plans).To(HaveKeyWithValue("b2-s1-p2-id", cfmodel.PlanData{
-					BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false}))
-				Expect(plans).ToNot(HaveKey("b1-s1-p1-id"))
+				Expect(plans).To(Equal(cfmodel.PlanMap{
+					"b2-s1-p1-id": cfmodel.PlanData{
+						GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+					"b2-s1-p2-id": cfmodel.PlanData{
+						GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+				}))
 			})
 
 			It("returns plans from multiple brokers", func() {
 				plans := resolver.GetBrokerPlans([]string{"b1", "b2"})
-				Expect(plans).To(HaveKeyWithValue("b1-s1-p1-id", cfmodel.PlanData{
-					BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false}))
-				Expect(plans).To(HaveKeyWithValue("b2-s1-p1-id", cfmodel.PlanData{
-					BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true}))
-				Expect(plans).To(HaveKeyWithValue("b2-s1-p2-id", cfmodel.PlanData{
-					BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false}))
+				Expect(plans).To(Equal(cfmodel.PlanMap{
+					"b1-s1-p1-id": cfmodel.PlanData{
+						GUID: "b1-s1-p1-id", BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+					"b2-s1-p1-id": cfmodel.PlanData{
+						GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+					"b2-s1-p2-id": cfmodel.PlanData{
+						GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+				}))
 			})
 		})
 	})
@@ -121,16 +133,29 @@ var _ = Describe("PlanResolver", func() {
 	Describe("Reset", func() {
 		It("replaces the old data with new one", func() {
 			resetResolver(broker1)
-			Expect(resolver.GetBrokerPlans([]string{"b1"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+			Expect(resolver.GetBrokerPlans([]string{"b1"})).To(Equal(cfmodel.PlanMap{
+				"b1-s1-p1-id": cfmodel.PlanData{
+					GUID: "b1-s1-p1-id", BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
 			}))
 			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(BeEmpty())
 
 			resetResolver(broker2)
 			Expect(resolver.GetBrokerPlans([]string{"b1"})).To(BeEmpty())
-			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
-				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+		})
+
+		It("Ignores inconsistent data", func() {
+			broker1.services[0].ServiceBrokerGuid = "no-such-broker"
+			broker2.plans[0].ServiceGuid = "no-such-service"
+			resetResolver(broker1, broker2)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
 			}))
 		})
 	})
@@ -138,23 +163,28 @@ var _ = Describe("PlanResolver", func() {
 	Describe("ResetBroker", func() {
 		It("replaces the data for one broker", func() {
 			resetResolver(broker1, broker2)
-			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
-				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
-				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(Equal(cfmodel.PlanMap{
+				"b1-s1-p1-id": cfmodel.PlanData{
+					GUID: "b1-s1-p1-id", BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
 			}))
 
 			resolver.ResetBroker(
-				broker1.broker,
-				broker1.services,
+				broker1.broker.Name,
 				[]cfclient.ServicePlan{
 					{Guid: "b1-s1-p2-id", Name: "b1-s1-p2", ServiceGuid: "b1-s1-id", UniqueId: "s1-p2-cid"},
 				},
 			)
-			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b1", CatalogPlanID: "s1-p2-cid", Public: false},
-				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
-				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(Equal(cfmodel.PlanMap{
+				"b1-s1-p2-id": cfmodel.PlanData{
+					GUID: "b1-s1-p2-id", BrokerName: "b1", CatalogPlanID: "s1-p2-cid", Public: false},
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
 			}))
 		})
 	})
@@ -162,16 +192,49 @@ var _ = Describe("PlanResolver", func() {
 	Describe("DeleteBroker", func() {
 		It("deletes the data for one broker", func() {
 			resetResolver(broker1, broker2)
-			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
-				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
-				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(Equal(cfmodel.PlanMap{
+				"b1-s1-p1-id": cfmodel.PlanData{
+					GUID: "b1-s1-p1-id", BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
 			}))
 
-			resolver.DeleteBroker(broker1.broker.Guid)
-			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
-				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
-				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			resolver.DeleteBroker(broker1.broker.Name)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+		})
+	})
+
+	Describe("UpdatePlan", func() {
+		It("updates the public property of the plan", func() {
+			resetResolver(broker2)
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+
+			resolver.UpdatePlan("s1-p1-cid", "b2", false)
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: false},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+
+			resolver.UpdatePlan("s1-p2-cid", "b2", true)
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(Equal(cfmodel.PlanMap{
+				"b2-s1-p1-id": cfmodel.PlanData{
+					GUID: "b2-s1-p1-id", BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: false},
+				"b2-s1-p2-id": cfmodel.PlanData{
+					GUID: "b2-s1-p2-id", BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: true},
 			}))
 		})
 	})

--- a/cf/cfmodel/plan_resolver_test.go
+++ b/cf/cfmodel/plan_resolver_test.go
@@ -1,0 +1,178 @@
+package cfmodel_test
+
+import (
+	"github.com/cloudfoundry-community/go-cfclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
+)
+
+var _ = Describe("PlanResolver", func() {
+
+	type brokerData struct {
+		broker   cfclient.ServiceBroker
+		services []cfclient.Service
+		plans    []cfclient.ServicePlan
+	}
+
+	var (
+		broker1 = brokerData{
+			broker: cfclient.ServiceBroker{Guid: "b1-id", Name: "b1"},
+			services: []cfclient.Service{
+				{Guid: "b1-s1-id", Label: "b1-s1", ServiceBrokerGuid: "b1-id"},
+			},
+			plans: []cfclient.ServicePlan{
+				{Guid: "b1-s1-p1-id", Name: "b1-s1-p1", ServiceGuid: "b1-s1-id", UniqueId: "s1-p1-cid"},
+			},
+		}
+		broker2 = brokerData{
+			broker: cfclient.ServiceBroker{Guid: "b2-id", Name: "b2"},
+			services: []cfclient.Service{
+				{Guid: "b2-s1-id", Label: "b2-s1", ServiceBrokerGuid: "b2-id"},
+			},
+			plans: []cfclient.ServicePlan{
+				{Guid: "b2-s1-p1-id", Name: "b2-s1-p1", ServiceGuid: "b2-s1-id", UniqueId: "s1-p1-cid", Public: true},
+				{Guid: "b2-s1-p2-id", Name: "b2-s1-p2", ServiceGuid: "b2-s1-id", UniqueId: "s1-p2-cid"},
+			},
+		}
+	)
+
+	var resolver *cfmodel.PlanResolver
+
+	resetResolver := func(brokers ...brokerData) {
+		var (
+			allBrokers  []cfclient.ServiceBroker
+			allServices []cfclient.Service
+			allPlans    []cfclient.ServicePlan
+		)
+		for _, b := range brokers {
+			allBrokers = append(allBrokers, b.broker)
+			allServices = append(allServices, b.services...)
+			allPlans = append(allPlans, b.plans...)
+		}
+		resolver.Reset(allBrokers, allServices, allPlans)
+	}
+
+	BeforeEach(func() {
+		resolver = cfmodel.NewPlanResolver()
+	})
+
+	Describe("GetPlan", func() {
+		Context("Empty resolver", func() {
+			It("It returns no plan", func() {
+				Expect(resolver.GetPlan("catalog-id", "broker-name")).To(BeNil())
+			})
+		})
+
+		Context("Non-empty resolver", func() {
+			BeforeEach(func() {
+				resetResolver(broker1, broker2)
+			})
+
+			It("returns the correct plan even if different brokers have plans with same catalog id", func() {
+				plan := resolver.GetPlan("s1-p1-cid", "b1")
+				Expect(plan.Guid).To(Equal("b1-s1-p1-id"))
+				plan = resolver.GetPlan("s1-p1-cid", "b2")
+				Expect(plan.Guid).To(Equal("b2-s1-p1-id"))
+			})
+
+			It("does not return a non-existing plan", func() {
+				Expect(resolver.GetPlan("s1-p1-cid", "broker-name")).To(BeNil())
+				Expect(resolver.GetPlan("catalog-id", "b1")).To(BeNil())
+			})
+		})
+
+	})
+
+	Describe("GetBrokerPlans", func() {
+		Context("Empty resolver", func() {
+			It("returns empty map", func() {
+				Expect(resolver.GetBrokerPlans([]string{"broker-name"})).To(BeEmpty())
+			})
+		})
+
+		Context("Non-empty resolver", func() {
+			BeforeEach(func() {
+				resetResolver(broker1, broker2)
+			})
+
+			It("returns existing broker plans", func() {
+				plans := resolver.GetBrokerPlans([]string{"b2"})
+				Expect(plans).To(HaveKeyWithValue("b2-s1-p1-id", cfmodel.PlanData{
+					BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true}))
+				Expect(plans).To(HaveKeyWithValue("b2-s1-p2-id", cfmodel.PlanData{
+					BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false}))
+				Expect(plans).ToNot(HaveKey("b1-s1-p1-id"))
+			})
+
+			It("returns plans from multiple brokers", func() {
+				plans := resolver.GetBrokerPlans([]string{"b1", "b2"})
+				Expect(plans).To(HaveKeyWithValue("b1-s1-p1-id", cfmodel.PlanData{
+					BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false}))
+				Expect(plans).To(HaveKeyWithValue("b2-s1-p1-id", cfmodel.PlanData{
+					BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true}))
+				Expect(plans).To(HaveKeyWithValue("b2-s1-p2-id", cfmodel.PlanData{
+					BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false}))
+			})
+		})
+	})
+
+	Describe("Reset", func() {
+		It("replaces the old data with new one", func() {
+			resetResolver(broker1)
+			Expect(resolver.GetBrokerPlans([]string{"b1"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+			}))
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(BeEmpty())
+
+			resetResolver(broker2)
+			Expect(resolver.GetBrokerPlans([]string{"b1"})).To(BeEmpty())
+			Expect(resolver.GetBrokerPlans([]string{"b2"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+		})
+	})
+
+	Describe("ResetBroker", func() {
+		It("replaces the data for one broker", func() {
+			resetResolver(broker1, broker2)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+
+			resolver.ResetBroker(
+				broker1.broker,
+				broker1.services,
+				[]cfclient.ServicePlan{
+					{Guid: "b1-s1-p2-id", Name: "b1-s1-p2", ServiceGuid: "b1-s1-id", UniqueId: "s1-p2-cid"},
+				},
+			)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b1", CatalogPlanID: "s1-p2-cid", Public: false},
+				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+		})
+	})
+
+	Describe("DeleteBroker", func() {
+		It("deletes the data for one broker", func() {
+			resetResolver(broker1, broker2)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b1", CatalogPlanID: "s1-p1-cid", Public: false},
+				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+
+			resolver.DeleteBroker(broker1.broker.Guid)
+			Expect(resolver.GetBrokerPlans([]string{"b1", "b2"})).To(ConsistOf([]cfmodel.PlanData{
+				{BrokerName: "b2", CatalogPlanID: "s1-p1-cid", Public: true},
+				{BrokerName: "b2", CatalogPlanID: "s1-p2-cid", Public: false},
+			}))
+		})
+	})
+})

--- a/cf/cfmodel/suite_test.go
+++ b/cf/cfmodel/suite_test.go
@@ -1,0 +1,13 @@
+package cfmodel_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCFModel(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CF Model")
+}

--- a/cf/client.go
+++ b/cf/client.go
@@ -53,7 +53,7 @@ func NewClient(config *Settings) (*PlatformClient, error) {
 	return &PlatformClient{
 		client:       cfClient,
 		settings:     config,
-		planResolver: &cfmodel.PlanResolver{},
+		planResolver: cfmodel.NewPlanResolver(),
 	}, nil
 }
 

--- a/cf/client.go
+++ b/cf/client.go
@@ -3,10 +3,15 @@ package cf
 import (
 	"fmt"
 
-	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/cloudfoundry-community/go-cfclient"
-
 	"github.com/pkg/errors"
+
+	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
+	"github.com/Peripli/service-broker-proxy/pkg/platform"
+)
+
+const (
+	cfPageSizeParam = "results-per-page"
 )
 
 // CloudFoundryErr type represents a CF error with improved error message
@@ -15,8 +20,9 @@ type CloudFoundryErr cfclient.CloudFoundryError
 // PlatformClient provides an implementation of the service-broker-proxy/pkg/cf/Client interface.
 // It is used to call into the cf that the proxy deployed at.
 type PlatformClient struct {
-	client   cfclient.CloudFoundryClient
-	settings *Settings
+	client       cfclient.CloudFoundryClient
+	settings     *Settings
+	planResolver *cfmodel.PlanResolver
 }
 
 // Broker returns platform client which can perform platform broker operations
@@ -45,8 +51,9 @@ func NewClient(config *Settings) (*PlatformClient, error) {
 	}
 
 	return &PlatformClient{
-		client:   cfClient,
-		settings: config,
+		client:       cfClient,
+		settings:     config,
+		planResolver: &cfmodel.PlanResolver{},
 	}, nil
 }
 

--- a/cf/query.go
+++ b/cf/query.go
@@ -1,0 +1,41 @@
+package cf
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type queryBuilder struct {
+	filters  map[string]string
+	pageSize int
+}
+
+func (q *queryBuilder) set(key string, elements []string) *queryBuilder {
+	if q.filters == nil {
+		q.filters = make(map[string]string)
+	}
+	searchParameters := strings.Join(elements, ",")
+	q.filters[key] = searchParameters
+	return q
+}
+
+func (q *queryBuilder) build() url.Values {
+	query := url.Values{}
+	for key, params := range q.filters {
+		query.Add("q", fmt.Sprintf("%s IN %s", key, params))
+	}
+	if q.pageSize > 0 {
+		query.Set(cfPageSizeParam, strconv.Itoa(q.pageSize))
+	}
+	return query
+}
+
+func (pc *PlatformClient) buildQuery(key string, values ...string) url.Values {
+	query := queryBuilder{
+		pageSize: pc.settings.CF.PageSize,
+	}
+	query.set(key, values)
+	return query.build()
+}

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -114,10 +114,7 @@ func (pc *PlatformClient) updatePlan(plan cfmodel.PlanData, isPublic bool) error
 		return nil
 	}
 
-	_, err := pc.UpdateServicePlan(plan.GUID, ServicePlanRequest{
-		Public: isPublic,
-	})
-	if err != nil {
+	if _, err := pc.UpdateServicePlan(plan.GUID, ServicePlanRequest{Public: isPublic}); err != nil {
 		return err
 	}
 

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -63,7 +63,7 @@ func (pc *PlatformClient) updateAccessForPlan(ctx context.Context, request *plat
 	return nil
 }
 
-func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfclient.ServicePlan, isEnabled bool, orgGUID string) {
+func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isEnabled bool, orgGUID string) {
 	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
 		if err := pc.updateOrgVisibilityForPlan(ctx, plan, isEnabled, orgGUID); err != nil {
 			return err
@@ -74,7 +74,7 @@ func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context
 	}
 }
 
-func (pc *PlatformClient) scheduleUpdatePlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfclient.ServicePlan, isPublic bool) {
+func (pc *PlatformClient) scheduleUpdatePlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isPublic bool) {
 	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
 		if err := pc.updatePlan(plan, isPublic); err != nil {
 			return err

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -63,10 +63,6 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 		return nil, wrapCFError(err)
 	}
 
-	if err := pc.reloadBroker(ctx, broker.Guid); err != nil {
-		return nil, err
-	}
-
 	response := &platform.ServiceBroker{
 		GUID:      broker.Guid,
 		Name:      broker.Name,
@@ -82,8 +78,6 @@ func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteSe
 	if err := pc.client.DeleteServiceBroker(r.GUID); err != nil {
 		return wrapCFError(err)
 	}
-
-	pc.planResolver.DeleteBroker(r.GUID)
 
 	return nil
 }
@@ -102,10 +96,6 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 	broker, err := pc.client.UpdateServiceBroker(r.GUID, request)
 	if err != nil {
 		return nil, wrapCFError(err)
-	}
-
-	if err := pc.reloadBroker(ctx, broker.Guid); err != nil {
-		return nil, err
 	}
 
 	response := &platform.ServiceBroker{

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -2,6 +2,8 @@ package cf
 
 import (
 	"context"
+	"net/url"
+	"strconv"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -10,7 +12,9 @@ import (
 // GetBrokers implements service-broker-proxy/pkg/cf/Client.GetBrokers and provides logic for
 // obtaining the brokers that are already registered in CF
 func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBroker, error) {
-	brokers, err := pc.client.ListServiceBrokers()
+	brokers, err := pc.client.ListServiceBrokersByQuery(url.Values{
+		cfPageSizeParam: []string{strconv.Itoa(pc.settings.CF.PageSize)},
+	})
 	if err != nil {
 		return nil, wrapCFError(err)
 	}
@@ -59,12 +63,15 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 		return nil, wrapCFError(err)
 	}
 
+	if err := pc.reloadBroker(ctx, broker.Guid); err != nil {
+		return nil, err
+	}
+
 	response := &platform.ServiceBroker{
 		GUID:      broker.Guid,
 		Name:      broker.Name,
 		BrokerURL: broker.BrokerURL,
 	}
-
 	return response, nil
 }
 
@@ -75,6 +82,8 @@ func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteSe
 	if err := pc.client.DeleteServiceBroker(r.GUID); err != nil {
 		return wrapCFError(err)
 	}
+
+	pc.planResolver.DeleteBroker(r.GUID)
 
 	return nil
 }
@@ -94,11 +103,15 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 	if err != nil {
 		return nil, wrapCFError(err)
 	}
+
+	if err := pc.reloadBroker(ctx, broker.Guid); err != nil {
+		return nil, err
+	}
+
 	response := &platform.ServiceBroker{
 		GUID:      broker.Guid,
 		Name:      broker.Name,
 		BrokerURL: broker.BrokerURL,
 	}
-
 	return response, nil
 }

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -30,9 +30,9 @@ func (pc *PlatformClient) GetVisibilitiesByBrokers(ctx context.Context, brokerNa
 	plans := pc.planResolver.GetBrokerPlans(brokerNames)
 	publicPlans := filterPublicPlans(plans)
 
-	visibilities, err := pc.getPlansVisibilities(ctx, getPlanIDs(plans))
+	visibilities, err := pc.getPlansVisibilities(ctx, getPlanGUIDs(plans))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get visibilities from platform")
+		return nil, err
 	}
 
 	result := make([]*platform.Visibility, 0, len(visibilities)+len(publicPlans))
@@ -71,12 +71,12 @@ func filterPublicPlans(plans cfmodel.PlanMap) []cfmodel.PlanData {
 	return publicPlans
 }
 
-func getPlanIDs(plans cfmodel.PlanMap) []string {
-	ids := make([]string, 0, len(plans))
-	for id := range plans {
-		ids = append(ids, id)
+func getPlanGUIDs(plans cfmodel.PlanMap) []string {
+	guids := make([]string, 0, len(plans))
+	for guid := range plans {
+		guids = append(guids, guid)
 	}
-	return ids
+	return guids
 }
 
 func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []string) ([]cfclient.ServicePlanVisibility, error) {

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -2,14 +2,10 @@ package cf
 
 import (
 	"context"
-	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
 	"sync"
 
+	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
-
 	"github.com/Peripli/service-manager/pkg/log"
 
 	"github.com/pkg/errors"
@@ -30,82 +26,34 @@ func (pc *PlatformClient) VisibilityScopeLabelKey() string {
 // GetVisibilitiesByBrokers returns platform visibilities grouped by brokers based on given SM brokers.
 // The visibilities are taken from CF cloud controller.
 // For public plans, visibilities are created so that sync with sm visibilities is possible
-// nolint: gocyclo
 func (pc *PlatformClient) GetVisibilitiesByBrokers(ctx context.Context, brokerNames []string) ([]*platform.Visibility, error) {
-	logger := log.C(ctx)
-	logger.Debugf("Gettings brokers from platform for names: %s", brokerNames)
-	platformBrokers, err := pc.getBrokersByName(ctx, brokerNames)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get brokers from platform")
-	}
-	logger.Debugf("%d platform brokers found", len(platformBrokers))
+	plans := pc.planResolver.GetBrokerPlans(brokerNames)
+	publicPlans := filterPublicPlans(plans)
 
-	services, err := pc.getServicesByBrokers(ctx, platformBrokers)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get services from platform")
-	}
-	logger.Debugf("%d platform services found", len(services))
-
-	plans, err := pc.getPlansByServices(ctx, services)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get plans from platform")
-	}
-	logger.Debugf("%d platform plans found", len(plans))
-
-	visibilities, err := pc.getPlansVisibilities(ctx, plans)
+	visibilities, err := pc.getPlansVisibilities(ctx, getPlanIDs(plans))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get visibilities from platform")
-	}
-
-	type planBrokerIDs struct {
-		PlanCatalogID      string
-		PlatformBrokerName string
-	}
-
-	planUUIDToMapping := make(map[string]planBrokerIDs)
-	platformBrokerGUIDToBrokerName := make(map[string]string)
-
-	publicPlans := make([]cfclient.ServicePlan, 0)
-
-	for _, broker := range platformBrokers {
-		// Extract SM broker ID from platform broker name
-		platformBrokerGUIDToBrokerName[broker.Guid] = broker.Name
-	}
-
-	for _, plan := range plans {
-		if plan.Public {
-			publicPlans = append(publicPlans, plan)
-		}
-		for _, service := range services {
-			if plan.ServiceGuid == service.Guid {
-				planUUIDToMapping[plan.Guid] = planBrokerIDs{
-					PlatformBrokerName: platformBrokerGUIDToBrokerName[service.ServiceBrokerGuid],
-					PlanCatalogID:      plan.UniqueId,
-				}
-			}
-		}
 	}
 
 	result := make([]*platform.Visibility, 0, len(visibilities)+len(publicPlans))
 
 	for _, visibility := range visibilities {
-		labels := make(map[string]string)
-		labels[OrgLabelKey] = visibility.OrganizationGuid
-		planMapping := planUUIDToMapping[visibility.ServicePlanGuid]
-
+		plan := plans[visibility.ServicePlanGuid]
 		result = append(result, &platform.Visibility{
 			Public:             false,
-			CatalogPlanID:      planMapping.PlanCatalogID,
-			PlatformBrokerName: planMapping.PlatformBrokerName,
-			Labels:             labels,
+			CatalogPlanID:      plan.CatalogPlanID,
+			PlatformBrokerName: plan.BrokerName,
+			Labels: map[string]string{
+				OrgLabelKey: visibility.OrganizationGuid,
+			},
 		})
 	}
 
 	for _, plan := range publicPlans {
 		result = append(result, &platform.Visibility{
 			Public:             true,
-			CatalogPlanID:      plan.UniqueId,
-			PlatformBrokerName: planUUIDToMapping[plan.Guid].PlatformBrokerName,
+			CatalogPlanID:      plan.CatalogPlanID,
+			PlatformBrokerName: plan.BrokerName,
 			Labels:             map[string]string{},
 		})
 	}
@@ -113,14 +61,32 @@ func (pc *PlatformClient) GetVisibilitiesByBrokers(ctx context.Context, brokerNa
 	return result, nil
 }
 
-func (pc *PlatformClient) getBrokersByName(ctx context.Context, names []string) ([]cfclient.ServiceBroker, error) {
+func filterPublicPlans(plans cfmodel.PlanMap) []cfmodel.PlanData {
+	publicPlans := []cfmodel.PlanData{}
+	for _, plan := range plans {
+		if plan.Public {
+			publicPlans = append(publicPlans, plan)
+		}
+	}
+	return publicPlans
+}
+
+func getPlanIDs(plans cfmodel.PlanMap) []string {
+	ids := make([]string, 0, len(plans))
+	for id := range plans {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []string) ([]cfclient.ServicePlanVisibility, error) {
+	var result []cfclient.ServicePlanVisibility
 	errorOccured := &reconcile.CompositeError{}
-	var mutex sync.Mutex
 	var wg sync.WaitGroup
+	var mutex sync.Mutex
 	wgLimitChannel := make(chan struct{}, pc.settings.Reconcile.MaxParallelRequests)
 
-	result := make([]cfclient.ServiceBroker, 0, len(names))
-	chunks := splitStringsIntoChunks(names, pc.settings.CF.ChunkSize)
+	chunks := splitStringsIntoChunks(planIDs, pc.settings.CF.ChunkSize)
 
 	for _, chunk := range chunks {
 		select {
@@ -134,154 +100,10 @@ func (pc *PlatformClient) getBrokersByName(ctx context.Context, names []string) 
 				<-wgLimitChannel
 				wg.Done()
 			}()
-			brokerNames := make([]string, 0, len(chunk))
-			brokerNames = append(brokerNames, chunk...)
-			query := queryBuilder{
-				pageSize: pc.settings.CF.PageSize,
-			}
-			query.set("name", brokerNames)
-			brokers, err := pc.client.ListServiceBrokersByQuery(query.build(ctx))
-			mutex.Lock()
-			defer mutex.Unlock()
-			if err != nil {
-				errorOccured.Add(err)
-			} else if errorOccured.Len() == 0 {
-				result = append(result, brokers...)
-			}
-		}(chunk)
-	}
-	wg.Wait()
-	if errorOccured.Len() != 0 {
-		return nil, errorOccured
-	}
-	return result, nil
-}
-
-func (pc *PlatformClient) getServicesByBrokers(ctx context.Context, brokers []cfclient.ServiceBroker) ([]cfclient.Service, error) {
-	errorOccured := &reconcile.CompositeError{}
-	var mutex sync.Mutex
-	var wg sync.WaitGroup
-	wgLimitChannel := make(chan struct{}, pc.settings.Reconcile.MaxParallelRequests)
-
-	result := make([]cfclient.Service, 0, len(brokers))
-	chunks := splitBrokersIntoChunks(brokers, pc.settings.CF.ChunkSize)
-
-	for _, chunk := range chunks {
-		select {
-		case <-ctx.Done():
-			return nil, errors.WithStack(ctx.Err())
-		case wgLimitChannel <- struct{}{}:
-		}
-		wg.Add(1)
-		go func(chunk []cfclient.ServiceBroker) {
-			defer func() {
-				<-wgLimitChannel
-				wg.Done()
-			}()
-			brokerGUIDs := make([]string, 0, len(chunk))
-			for _, broker := range chunk {
-				brokerGUIDs = append(brokerGUIDs, broker.Guid)
-			}
-			brokers, err := pc.getServicesByBrokerGUIDs(ctx, brokerGUIDs)
-			mutex.Lock()
-			defer mutex.Unlock()
-			if err != nil {
-				errorOccured.Add(err)
-			} else if errorOccured.Len() == 0 {
-				result = append(result, brokers...)
-			}
-		}(chunk)
-	}
-	wg.Wait()
-	if errorOccured.Len() != 0 {
-		return nil, errorOccured
-	}
-	return result, nil
-}
-
-func (pc *PlatformClient) getServicesByBrokerGUIDs(ctx context.Context, brokerGUIDs []string) ([]cfclient.Service, error) {
-	query := queryBuilder{
-		pageSize: pc.settings.CF.PageSize,
-	}
-	query.set("service_broker_guid", brokerGUIDs)
-	return pc.client.ListServicesByQuery(query.build(ctx))
-}
-
-func (pc *PlatformClient) getPlansByServices(ctx context.Context, services []cfclient.Service) ([]cfclient.ServicePlan, error) {
-	errorOccured := &reconcile.CompositeError{}
-	var mutex sync.Mutex
-	var wg sync.WaitGroup
-	wgLimitChannel := make(chan struct{}, pc.settings.Reconcile.MaxParallelRequests)
-
-	result := make([]cfclient.ServicePlan, 0, len(services))
-	chunks := splitServicesIntoChunks(services, pc.settings.CF.ChunkSize)
-
-	for _, chunk := range chunks {
-		select {
-		case <-ctx.Done():
-			return nil, errors.WithStack(ctx.Err())
-		case wgLimitChannel <- struct{}{}:
-		}
-		wg.Add(1)
-		go func(chunk []cfclient.Service) {
-			defer func() {
-				<-wgLimitChannel
-				wg.Done()
-			}()
-			serviceGUIDs := make([]string, 0, len(chunk))
-			for _, service := range chunk {
-				serviceGUIDs = append(serviceGUIDs, service.Guid)
-			}
-			plans, err := pc.getPlansByServiceGUIDs(ctx, serviceGUIDs)
-			mutex.Lock()
-			defer mutex.Unlock()
-			if err != nil {
-				errorOccured.Add(err)
-			} else if errorOccured.Len() == 0 {
-				result = append(result, plans...)
-			}
-		}(chunk)
-	}
-	wg.Wait()
-	if errorOccured.Len() != 0 {
-		return nil, errorOccured
-	}
-	return result, nil
-}
-
-func (pc *PlatformClient) getPlansByServiceGUIDs(ctx context.Context, serviceGUIDs []string) ([]cfclient.ServicePlan, error) {
-	query := queryBuilder{
-		pageSize: pc.settings.CF.PageSize,
-	}
-	query.set("service_guid", serviceGUIDs)
-	return pc.client.ListServicePlansByQuery(query.build(ctx))
-}
-
-func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, plans []cfclient.ServicePlan) ([]cfclient.ServicePlanVisibility, error) {
-	var result []cfclient.ServicePlanVisibility
-	errorOccured := &reconcile.CompositeError{}
-	var wg sync.WaitGroup
-	var mutex sync.Mutex
-	wgLimitChannel := make(chan struct{}, pc.settings.Reconcile.MaxParallelRequests)
-
-	chunks := splitCFPlansIntoChunks(plans, pc.settings.CF.ChunkSize)
-
-	for _, chunk := range chunks {
-		select {
-		case <-ctx.Done():
-			return nil, errors.WithStack(ctx.Err())
-		case wgLimitChannel <- struct{}{}:
-		}
-		wg.Add(1)
-		go func(chunk []cfclient.ServicePlan) {
-			defer func() {
-				<-wgLimitChannel
-				wg.Done()
-			}()
 
 			plansGUID := make([]string, 0, len(chunk))
-			for _, p := range chunk {
-				plansGUID = append(plansGUID, p.Guid)
+			for _, guid := range chunk {
+				plansGUID = append(plansGUID, guid)
 			}
 			visibilities, err := pc.getPlanVisibilitiesByPlanGUID(ctx, plansGUID)
 			mutex.Lock()
@@ -301,39 +123,14 @@ func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, plans []cfcl
 }
 
 func (pc *PlatformClient) getPlanVisibilitiesByPlanGUID(ctx context.Context, plansGUID []string) ([]cfclient.ServicePlanVisibility, error) {
-	query := queryBuilder{
-		pageSize: pc.settings.CF.PageSize,
+	logger := log.C(ctx)
+	logger.Infof("Loading visibilities for service plans with GUIDs %v from Cloud Foundry...", plansGUID)
+	vis, err := pc.client.ListServicePlanVisibilitiesByQuery(
+		pc.buildQuery("service_plan_guid", plansGUID...))
+	if err == nil {
+		logger.Infof("Loaded %d visibilities from Cloud Foundry", len(vis))
 	}
-	query.set("service_plan_guid", plansGUID)
-	return pc.client.ListServicePlanVisibilitiesByQuery(query.build(ctx))
-}
-
-type queryBuilder struct {
-	filters  map[string]string
-	pageSize int
-}
-
-func (q *queryBuilder) set(key string, elements []string) *queryBuilder {
-	if q.filters == nil {
-		q.filters = make(map[string]string)
-	}
-	searchParameters := strings.Join(elements, ",")
-	q.filters[key] = searchParameters
-	return q
-}
-
-func (q *queryBuilder) build(ctx context.Context) map[string][]string {
-	queryComponents := make([]string, 0)
-	for key, params := range q.filters {
-		component := fmt.Sprintf("%s IN %s", key, params)
-		queryComponents = append(queryComponents, component)
-	}
-	query := strings.Join(queryComponents, ";")
-	log.C(ctx).Debugf("CF filter query built: %s", query)
-	return url.Values{
-		"q":                []string{query},
-		"results-per-page": []string{strconv.Itoa(q.pageSize)},
-	}
+	return vis, err
 }
 
 func splitCFPlansIntoChunks(plans []cfclient.ServicePlan, maxChunkLength int) [][]cfclient.ServicePlan {

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -101,11 +101,7 @@ func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []st
 				wg.Done()
 			}()
 
-			plansGUID := make([]string, 0, len(chunk))
-			for _, guid := range chunk {
-				plansGUID = append(plansGUID, guid)
-			}
-			visibilities, err := pc.getPlanVisibilitiesByPlanGUID(ctx, plansGUID)
+			visibilities, err := pc.getPlanVisibilitiesByPlanGUID(ctx, chunk)
 			mutex.Lock()
 			defer mutex.Unlock()
 			if err != nil {
@@ -133,17 +129,6 @@ func (pc *PlatformClient) getPlanVisibilitiesByPlanGUID(ctx context.Context, pla
 	return vis, err
 }
 
-func splitCFPlansIntoChunks(plans []cfclient.ServicePlan, maxChunkLength int) [][]cfclient.ServicePlan {
-	resultChunks := make([][]cfclient.ServicePlan, 0)
-
-	for count := len(plans); count > 0; count = len(plans) {
-		sliceLength := min(count, maxChunkLength)
-		resultChunks = append(resultChunks, plans[:sliceLength])
-		plans = plans[sliceLength:]
-	}
-	return resultChunks
-}
-
 func splitStringsIntoChunks(names []string, maxChunkLength int) [][]string {
 	resultChunks := make([][]string, 0)
 
@@ -151,28 +136,6 @@ func splitStringsIntoChunks(names []string, maxChunkLength int) [][]string {
 		sliceLength := min(count, maxChunkLength)
 		resultChunks = append(resultChunks, names[:sliceLength])
 		names = names[sliceLength:]
-	}
-	return resultChunks
-}
-
-func splitBrokersIntoChunks(brokers []cfclient.ServiceBroker, maxChunkLength int) [][]cfclient.ServiceBroker {
-	resultChunks := make([][]cfclient.ServiceBroker, 0)
-
-	for count := len(brokers); count > 0; count = len(brokers) {
-		sliceLength := min(count, maxChunkLength)
-		resultChunks = append(resultChunks, brokers[:sliceLength])
-		brokers = brokers[sliceLength:]
-	}
-	return resultChunks
-}
-
-func splitServicesIntoChunks(services []cfclient.Service, maxChunkLength int) [][]cfclient.Service {
-	resultChunks := make([][]cfclient.Service, 0)
-
-	for count := len(services); count > 0; count = len(services) {
-		sliceLength := min(count, maxChunkLength)
-		resultChunks = append(resultChunks, services[:sliceLength])
-		services = services[sliceLength:]
 	}
 	return resultChunks
 }


### PR DESCRIPTION
Load all service plans from CF between brokers and visibility resync
Use this data to look up in memory:
* All the plans from SM-managed brokers during visibility resync
* The plan guid from broker name and catalog id during visibility update (save 3 calls to CF per visibility)

Update in-memory data on each broker change

Depends on https://github.com/Peripli/service-broker-proxy/pull/122