### PR TITLE
Fix large logs

### DIFF
--- a/cf/client.go
+++ b/cf/client.go
@@ -1,10 +1,7 @@
 package cf
 
 import (
-	"fmt"
-
 	"github.com/cloudfoundry-community/go-cfclient"
-	"github.com/pkg/errors"
 
 	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
@@ -13,9 +10,6 @@ import (
 const (
 	cfPageSizeParam = "results-per-page"
 )
-
-// CloudFoundryErr type represents a CF error with improved error message
-type CloudFoundryErr cfclient.CloudFoundryError
 
 // PlatformClient provides an implementation of the service-broker-proxy/pkg/cf/Client interface.
 // It is used to call into the cf that the proxy deployed at.
@@ -55,16 +49,4 @@ func NewClient(config *Settings) (*PlatformClient, error) {
 		settings:     config,
 		planResolver: cfmodel.NewPlanResolver(),
 	}, nil
-}
-
-func (e CloudFoundryErr) Error() string {
-	return fmt.Sprintf("cfclient: error (%d): %s %s", e.Code, e.ErrorCode, e.Description)
-}
-
-func wrapCFError(err error) error {
-	cause, ok := errors.Cause(err).(cfclient.CloudFoundryError)
-	if ok {
-		return errors.WithStack(CloudFoundryErr(cause))
-	}
-	return err
 }

--- a/cf/client_test.go
+++ b/cf/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy"
@@ -14,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pkg/errors"
 )
 
 const InvalidJSON = `{invalidjson`
@@ -121,9 +121,13 @@ func verifyReqReceived(server *ghttp.Server, times int, method, path string, raw
 	}
 }
 
-func assertErrCauseIsCFError(actualErr error, expectedErr cf.CloudFoundryErr) {
-	cause := errors.Cause(actualErr).(cf.CloudFoundryErr)
-	Expect(cause).To(MatchError(expectedErr))
+func assertCFError(actualErr error, expectedErr cfclient.CloudFoundryError) {
+	Expect(actualErr).ToNot(BeNil())
+	Expect(actualErr.Error()).To(SatisfyAll(
+		ContainSubstring(strconv.Itoa(expectedErr.Code)),
+		ContainSubstring(expectedErr.ErrorCode),
+		ContainSubstring(expectedErr.Description),
+	))
 }
 
 func ccClient(URL string) (*cf.Settings, *cf.PlatformClient) {

--- a/cf/fetch_catalog_test.go
+++ b/cf/fetch_catalog_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Client FetchCatalog", func() {
 		testBroker      *platform.ServiceBroker
 		ccResponseCode  int
 		ccResponse      interface{}
-		ccResponseErr   cf.CloudFoundryErr
+		ccResponseErr   cfclient.CloudFoundryError
 		expectedRequest interface{}
 		err             error
 		ctx             context.Context
@@ -99,7 +99,7 @@ var _ = Describe("Client FetchCatalog", func() {
 
 		Context("when UpdateBroker returns an error", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -118,7 +118,7 @@ var _ = Describe("Client FetchCatalog", func() {
 					Password:  brokerPassword,
 				})
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 		})
 	})

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -90,7 +90,7 @@ func (pc *PlatformClient) updateOrgVisibilityForPlan(ctx context.Context, plan c
 			"visibility for org with GUID %s will be ignored", plan.GUID, orgGUID)
 	case isEnabled:
 		if _, err := pc.client.CreateServicePlanVisibility(plan.GUID, orgGUID); err != nil {
-			return fmt.Errorf("Could not enable access for plan with GUID %s in organization with GUID %s: %v",
+			return fmt.Errorf("could not enable access for plan with GUID %s in organization with GUID %s: %v",
 				plan.GUID, orgGUID, err)
 		}
 		logger.Infof("Enabled access for plan with GUID %s in organization with GUID %s",
@@ -132,7 +132,7 @@ func (pc *PlatformClient) deleteAccessVisibilities(ctx context.Context, query ur
 
 	for _, visibility := range servicePlanVisibilities {
 		if err := pc.client.DeleteServicePlanVisibility(visibility.Guid, false); err != nil {
-			return fmt.Errorf("Could not disable access for plan with GUID %s in organization with GUID %s: %v",
+			return fmt.Errorf("could not disable access for plan with GUID %s in organization with GUID %s: %v",
 				visibility.ServicePlanGuid, visibility.OrganizationGuid, err)
 		}
 		log.C(ctx).Infof("Disabled access for plan with GUID %s in organization with GUID %s",
@@ -146,7 +146,7 @@ func (pc *PlatformClient) deleteAccessVisibilities(ctx context.Context, query ur
 func (pc *PlatformClient) UpdateServicePlan(ctx context.Context, planGUID string, request ServicePlanRequest) (cfclient.ServicePlan, error) {
 	plan, err := pc.updateServicePlan(planGUID, request)
 	if err != nil {
-		err = fmt.Errorf("Could not update service plan with GUID %s: %v", planGUID, err)
+		err = fmt.Errorf("could not update service plan with GUID %s: %v", planGUID, err)
 	} else {
 		log.C(ctx).Infof("Service plan with GUID %s updated to public: %v", planGUID, request.Public)
 	}

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -56,8 +56,8 @@ func (pc *PlatformClient) updateAccessForPlan(ctx context.Context, request *plat
 		pc.scheduleUpdatePlan(ctx, request, scheduler, plan, isEnabled)
 	}
 	if err := scheduler.Await(); err != nil {
-		compositeErr := err.(*reconcile.CompositeError)
-		return errors.Wrapf(compositeErr, "error while updating access for catalog plan with id %s; %d errors occurred: %s", request.CatalogPlanID, compositeErr.Len(), compositeErr)
+		return fmt.Errorf("error while updating access for catalog plan with id %s: %v",
+			request.CatalogPlanID, err)
 	}
 
 	return nil
@@ -65,10 +65,7 @@ func (pc *PlatformClient) updateAccessForPlan(ctx context.Context, request *plat
 
 func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isEnabled bool, orgGUID string) {
 	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
-		if err := pc.updateOrgVisibilityForPlan(ctx, plan, isEnabled, orgGUID); err != nil {
-			return err
-		}
-		return nil
+		return pc.updateOrgVisibilityForPlan(ctx, plan, isEnabled, orgGUID)
 	}); schedulerErr != nil {
 		log.C(ctx).Warningf("Could not schedule task for update plan with catalog id %s", request.CatalogPlanID)
 	}
@@ -76,10 +73,7 @@ func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context
 
 func (pc *PlatformClient) scheduleUpdatePlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isPublic bool) {
 	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
-		if err := pc.updatePlan(plan, isPublic); err != nil {
-			return err
-		}
-		return nil
+		return pc.updatePlan(plan, isPublic)
 	}); schedulerErr != nil {
 		log.C(ctx).Warningf("Could not schedule task for update plan with catalog id %s", request.CatalogPlanID)
 	}

--- a/cf/service_access_test.go
+++ b/cf/service_access_test.go
@@ -1083,7 +1083,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(planGUID, requestBody)
+				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
 
 				assertCFError(err, ccResponseErrBody)
 
@@ -1097,7 +1097,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(planGUID, requestBody)
+				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
 
 				Expect(err).Should(HaveOccurred())
 
@@ -1111,7 +1111,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(planGUID, requestBody)
+				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
 
 				Expect(err).Should(HaveOccurred())
 			})
@@ -1124,7 +1124,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			})
 
 			It("returns the updated service plan", func() {
-				plan, err := client.UpdateServicePlan(planGUID, requestBody)
+				plan, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(plan).Should(BeEquivalentTo(planDetails[planGUID].updatePlanResponse.Entity))

--- a/cf/service_access_test.go
+++ b/cf/service_access_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Client Service Plan Access", func() {
 		emptyOrgData types.Labels
 		err          error
 
-		ccResponseErrBody cf.CloudFoundryErr
+		ccResponseErrBody cfclient.CloudFoundryError
 		ccResponseErrCode int
 
 		publicPlan  cfclient.ServicePlanResource
@@ -254,7 +254,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			},
 		}
 
-		ccResponseErrBody = cf.CloudFoundryErr{
+		ccResponseErrBody = cfclient.CloudFoundryError{
 			Code:        1009,
 			ErrorCode:   "err",
 			Description: "test err",
@@ -482,7 +482,7 @@ var _ = Describe("Client Service Plan Access", func() {
 					getPlansRoute.reaction.Code = ccResponseErrCode
 				})
 
-				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, fmt.Errorf(ccResponseErrBody.Description)))
+				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
 			})
 
 			Context("when no plan is found", func() {
@@ -1085,7 +1085,7 @@ var _ = Describe("Client Service Plan Access", func() {
 			It("returns an error", func() {
 				_, err := client.UpdateServicePlan(planGUID, requestBody)
 
-				assertErrCauseIsCFError(err, ccResponseErrBody)
+				assertCFError(err, ccResponseErrBody)
 
 			})
 		})

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -47,7 +47,7 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*platform.ServiceBroker, error) {
 	broker, err := pc.client.GetServiceBrokerByName(name)
 	if err != nil {
-		return nil, fmt.Errorf("Could not retrieve service broker with name %s: %v", name, err)
+		return nil, fmt.Errorf("could not retrieve service broker with name %s: %v", name, err)
 	}
 	log.C(ctx).Infof("Retrieved service broker with name %s, GUID %s and URL %s",
 		broker.Name, broker.Guid, broker.BrokerURL)
@@ -72,7 +72,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 
 	broker, err := pc.client.CreateServiceBroker(request)
 	if err != nil {
-		return nil, fmt.Errorf("Could not create service broker with name %s: %v", r.Name, err)
+		return nil, fmt.Errorf("could not create service broker with name %s: %v", r.Name, err)
 	}
 	log.C(ctx).Infof("Created service broker with name %s and URL %s", r.Name, r.BrokerURL)
 
@@ -88,7 +88,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 // deleting broker in CF
 func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteServiceBrokerRequest) error {
 	if err := pc.client.DeleteServiceBroker(r.GUID); err != nil {
-		return fmt.Errorf("Could not delete service broker with GUID %s: %v", r.GUID, err)
+		return fmt.Errorf("could not delete service broker with GUID %s: %v", r.GUID, err)
 	}
 	log.C(ctx).Infof("Deleted service broker with GUID %s", r.GUID)
 	return nil
@@ -99,7 +99,7 @@ func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteSe
 func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
 	broker, err := pc.updateBroker(ctx, r)
 	if err != nil {
-		err = fmt.Errorf("Could not update service broker with GUID %s: %v", r.GUID, err)
+		err = fmt.Errorf("could not update service broker with GUID %s: %v", r.GUID, err)
 	} else {
 		log.C(ctx).Infof("Updated service broker with GUID %s, name %s and URL %s",
 			broker.GUID, broker.Name, broker.BrokerURL)

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -19,12 +19,15 @@ import (
 // GetBrokers implements service-broker-proxy/pkg/cf/Client.GetBrokers and provides logic for
 // obtaining the brokers that are already registered in CF
 func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBroker, error) {
+	logger := log.C(ctx)
+	logger.Info("Fetching service brokers from CF...")
 	brokers, err := pc.client.ListServiceBrokersByQuery(url.Values{
 		cfPageSizeParam: []string{strconv.Itoa(pc.settings.CF.PageSize)},
 	})
 	if err != nil {
 		return nil, err
 	}
+	logger.Infof("Fetched %d service brokers from CF", len(brokers))
 
 	var clientBrokers []*platform.ServiceBroker
 	for _, broker := range brokers {
@@ -44,8 +47,10 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*platform.ServiceBroker, error) {
 	broker, err := pc.client.GetServiceBrokerByName(name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not retrieve service broker with name %s: %v", name, err)
 	}
+	log.C(ctx).Infof("Retrieved service broker with name %s, GUID %s and URL %s",
+		broker.Name, broker.Guid, broker.BrokerURL)
 
 	return &platform.ServiceBroker{
 		GUID:      broker.Guid,
@@ -67,8 +72,9 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 
 	broker, err := pc.client.CreateServiceBroker(request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not create service broker with name %s: %v", r.Name, err)
 	}
+	log.C(ctx).Infof("Created service broker with name %s and URL %s", r.Name, r.BrokerURL)
 
 	response := &platform.ServiceBroker{
 		GUID:      broker.Guid,
@@ -82,15 +88,26 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 // deleting broker in CF
 func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteServiceBrokerRequest) error {
 	if err := pc.client.DeleteServiceBroker(r.GUID); err != nil {
-		return err
+		return fmt.Errorf("Could not delete service broker with GUID %s: %v", r.GUID, err)
 	}
-
+	log.C(ctx).Infof("Deleted service broker with GUID %s", r.GUID)
 	return nil
 }
 
 // UpdateBroker implements service-broker-proxy/pkg/cf/Client.UpdateBroker and provides logic for
 // updating a broker registration in CF
 func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
+	broker, err := pc.updateBroker(ctx, r)
+	if err != nil {
+		err = fmt.Errorf("Could not update service broker with GUID %s: %v", r.GUID, err)
+	} else {
+		log.C(ctx).Infof("Updated service broker with GUID %s, name %s and URL %s",
+			broker.GUID, broker.Name, broker.BrokerURL)
+	}
+	return broker, err
+}
+
+func (pc *PlatformClient) updateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
 	request := struct {
 		Name      string `json:"name"`
 		BrokerURL string `json:"broker_url"`

--- a/cf/service_broker_test.go
+++ b/cf/service_broker_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Client ServiceBroker", func() {
 		testBroker      *platform.ServiceBroker
 		ccResponseCode  int
 		ccResponse      interface{}
-		ccResponseErr   cf.CloudFoundryErr
+		ccResponseErr   cfclient.CloudFoundryError
 		expectedRequest interface{}
 		ctx             context.Context
 	)
@@ -65,7 +65,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when an error status code is returned by CC", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -78,7 +78,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			It("returns an error", func() {
 				_, err := client.GetBrokers(ctx)
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 
 		})
@@ -148,7 +148,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when an error status code is returned by CC", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -161,7 +161,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			It("returns an error", func() {
 				_, err := client.GetBrokerByName(ctx, brokerName)
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 		})
 
@@ -242,7 +242,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when an error status code is returned by CC", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -255,7 +255,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			It("returns an error", func() {
 				_, err := client.CreateBroker(ctx, actualRequest)
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 		})
 
@@ -302,7 +302,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when an error status code is returned by CC", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -315,7 +315,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			It("returns an error", func() {
 				err := client.DeleteBroker(ctx, actualRequest)
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 		})
 
@@ -364,7 +364,7 @@ var _ = Describe("Client ServiceBroker", func() {
 		})
 		Context("when an error status code is returned by CC", func() {
 			BeforeEach(func() {
-				ccResponseErr = cf.CloudFoundryErr{
+				ccResponseErr = cfclient.CloudFoundryError{
 					Code:        1009,
 					ErrorCode:   "err",
 					Description: "test err",
@@ -377,7 +377,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			It("returns an error", func() {
 				_, err := client.UpdateBroker(ctx, actualRequest)
 
-				assertErrCauseIsCFError(err, ccResponseErr)
+				assertCFError(err, ccResponseErr)
 			})
 		})
 

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -85,7 +85,7 @@ func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []st
 	chunks := splitStringsIntoChunks(planIDs, pc.settings.CF.ChunkSize)
 	for _, chunk := range chunks {
 		chunk := chunk // copy for goroutine
-		scheduler.Schedule(func(ctx context.Context) error {
+		err := scheduler.Schedule(func(ctx context.Context) error {
 			visibilities, err := pc.getPlanVisibilitiesByPlanGUID(ctx, chunk)
 			if err != nil {
 				return err
@@ -96,6 +96,9 @@ func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []st
 			result = append(result, visibilities...)
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := scheduler.Await(); err != nil {

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -8,8 +8,6 @@ import (
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"github.com/Peripli/service-manager/pkg/log"
 
-	"github.com/pkg/errors"
-
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -81,39 +79,27 @@ func getPlanGUIDs(plans cfmodel.PlanMap) []string {
 
 func (pc *PlatformClient) getPlansVisibilities(ctx context.Context, planIDs []string) ([]cfclient.ServicePlanVisibility, error) {
 	var result []cfclient.ServicePlanVisibility
-	errorOccured := &reconcile.CompositeError{}
-	var wg sync.WaitGroup
-	var mutex sync.Mutex
-	wgLimitChannel := make(chan struct{}, pc.settings.Reconcile.MaxParallelRequests)
+	var mutex sync.Mutex // protects result
+	scheduler := reconcile.NewScheduler(ctx, pc.settings.Reconcile.MaxParallelRequests)
 
 	chunks := splitStringsIntoChunks(planIDs, pc.settings.CF.ChunkSize)
-
 	for _, chunk := range chunks {
-		select {
-		case <-ctx.Done():
-			return nil, errors.WithStack(ctx.Err())
-		case wgLimitChannel <- struct{}{}:
-		}
-		wg.Add(1)
-		go func(chunk []string) {
-			defer func() {
-				<-wgLimitChannel
-				wg.Done()
-			}()
-
+		chunk := chunk // copy for goroutine
+		scheduler.Schedule(func(ctx context.Context) error {
 			visibilities, err := pc.getPlanVisibilitiesByPlanGUID(ctx, chunk)
+			if err != nil {
+				return err
+			}
+
 			mutex.Lock()
 			defer mutex.Unlock()
-			if err != nil {
-				errorOccured.Add(err)
-			} else if errorOccured.Len() == 0 {
-				result = append(result, visibilities...)
-			}
-		}(chunk)
+			result = append(result, visibilities...)
+			return nil
+		})
 	}
-	wg.Wait()
-	if errorOccured.Len() != 0 {
-		return nil, errorOccured
+
+	if err := scheduler.Await(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/cf/service_visibilities_test.go
+++ b/cf/service_visibilities_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		generatedCFServices     map[string][]*cfclient.Service
 		generatedCFPlans        map[string][]*cfclient.ServicePlan
 		generatedCFVisibilities map[string]*cfclient.ServicePlanVisibility
-		expectedCFVisibiltiies  map[string]*platform.Visibility
+		expectedCFVisibilities  map[string]*platform.Visibility
 
 		maxAllowedParallelRequests int
 		parallelRequestsCounter    int
@@ -360,7 +360,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		generatedCFBrokers = generateCFBrokers(5)
 		generatedCFServices = generateCFServices(generatedCFBrokers, 10)
 		generatedCFPlans = generateCFPlans(generatedCFServices, 15, 2)
-		generatedCFVisibilities, expectedCFVisibiltiies = generateCFVisibilities(generatedCFPlans)
+		generatedCFVisibilities, expectedCFVisibilities = generateCFVisibilities(generatedCFPlans)
 
 		parallelRequestsCounter = 0
 		maxAllowedParallelRequests = 3
@@ -383,7 +383,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 				platformVisibilities, err := getVisibilitiesByBrokers(ctx, getBrokerNames(generatedCFBrokers))
 				Expect(err).ShouldNot(HaveOccurred())
 
-				for _, expectedCFVisibility := range expectedCFVisibiltiies {
+				for _, expectedCFVisibility := range expectedCFVisibilities {
 					Expect(platformVisibilities).Should(ContainElement(expectedCFVisibility))
 				}
 			})
@@ -402,7 +402,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 						serviceGUID := service.Guid
 						for _, plan := range generatedCFPlans[serviceGUID] {
 							planGUID := plan.Guid
-							expectedVis := expectedCFVisibiltiies[planGUID]
+							expectedVis := expectedCFVisibilities[planGUID]
 							Expect(platformVisibilities).Should(ContainElement(expectedVis))
 						}
 					}


### PR DESCRIPTION
Log calls to CF
Remove `wrapCFError` as it did not add value but removed the wrapping error, so its message was lost.