### PR TITLE
Ignore space-scoped brokers

### DIFF
--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -41,6 +41,7 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 		}
 	}
 
+	logger.Infof("Filtered out %d space-scoped brokers", len(brokers)-len(clientBrokers))
 	return clientBrokers, nil
 }
 
@@ -55,7 +56,7 @@ func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*pl
 		broker.Name, broker.Guid, broker.BrokerURL)
 
 	if broker.SpaceGUID != "" {
-		return nil, fmt.Errorf("service broker with name %s, GUID %s and URL %s is space-scoped", broker.Name, broker.Guid, broker.BrokerURL)
+		return nil, fmt.Errorf("service broker with name %s and GUID %s is scoped to a space with GUID %s", broker.Name, broker.Guid, broker.SpaceGUID)
 	}
 
 	return &platform.ServiceBroker{

--- a/cf/service_broker.go
+++ b/cf/service_broker.go
@@ -31,12 +31,14 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 
 	var clientBrokers []*platform.ServiceBroker
 	for _, broker := range brokers {
-		serviceBroker := &platform.ServiceBroker{
-			GUID:      broker.Guid,
-			Name:      broker.Name,
-			BrokerURL: broker.BrokerURL,
+		if broker.SpaceGUID == "" {
+			serviceBroker := &platform.ServiceBroker{
+				GUID:      broker.Guid,
+				Name:      broker.Name,
+				BrokerURL: broker.BrokerURL,
+			}
+			clientBrokers = append(clientBrokers, serviceBroker)
 		}
-		clientBrokers = append(clientBrokers, serviceBroker)
 	}
 
 	return clientBrokers, nil
@@ -51,6 +53,10 @@ func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*pl
 	}
 	log.C(ctx).Infof("Retrieved service broker with name %s, GUID %s and URL %s",
 		broker.Name, broker.Guid, broker.BrokerURL)
+
+	if broker.SpaceGUID != "" {
+		return nil, fmt.Errorf("service broker with name %s, GUID %s and URL %s is space-scoped", broker.Name, broker.Guid, broker.BrokerURL)
+	}
 
 	return &platform.ServiceBroker{
 		GUID:      broker.Guid,

--- a/cf/service_broker_test.go
+++ b/cf/service_broker_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 var _ = Describe("Client ServiceBroker", func() {
+
+	const cfSpaceGUID = "cf-space-guid"
+
 	var (
 		client              *cf.PlatformClient
 		ccServer            *ghttp.Server
@@ -72,7 +75,7 @@ var _ = Describe("Client ServiceBroker", func() {
 			Guid:      testBroker.GUID + spaceScopedSuffix,
 			Name:      testBroker.Name + spaceScopedSuffix,
 			BrokerURL: testBroker.BrokerURL + spaceScopedSuffix,
-			SpaceGUID: "cf-space-guid",
+			SpaceGUID: cfSpaceGUID,
 		}
 
 		ccServer = fakeCCServer(false)
@@ -225,8 +228,8 @@ var _ = Describe("Client ServiceBroker", func() {
 					_, err := client.GetBrokerByName(ctx, ccSpaceScopedBroker.Name)
 
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal(fmt.Sprintf("service broker with name %s, GUID %s and URL %s is space-scoped",
-						ccSpaceScopedBroker.Name, ccSpaceScopedBroker.Guid, ccSpaceScopedBroker.BrokerURL)))
+					Expect(err.Error()).To(Equal(fmt.Sprintf("service broker with name %s and GUID %s is scoped to a space with GUID %s",
+						ccSpaceScopedBroker.Name, ccSpaceScopedBroker.Guid, cfSpaceGUID)))
 				})
 			})
 		})

--- a/cf/service_broker_test.go
+++ b/cf/service_broker_test.go
@@ -206,24 +206,22 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when a broker with the specified name exists in CC", func() {
 			BeforeEach(func() {
-				ccResponse = ccBrokersResponse(ccGlobalBroker)
 				ccResponseCode = http.StatusOK
 			})
 
-			It("returns the broker", func() {
-				broker, err := client.GetBrokerByName(ctx, brokerName)
+			Context("when the broker is global", func() {
+				It("returns the broker", func() {
+					ccResponse = ccBrokersResponse(ccGlobalBroker)
+					broker, err := client.GetBrokerByName(ctx, brokerName)
 
-				Expect(err).ShouldNot(HaveOccurred())
-				assertBrokersFoundMatchTestBroker(1, broker)
+					Expect(err).ShouldNot(HaveOccurred())
+					assertBrokersFoundMatchTestBroker(1, broker)
+				})
 			})
 
 			Context("when the broker is space-scoped", func() {
-				BeforeEach(func() {
-					ccResponse = ccBrokersResponse(ccSpaceScopedBroker)
-					ccResponseCode = http.StatusOK
-				})
-
 				It("returns an error", func() {
+					ccResponse = ccBrokersResponse(ccSpaceScopedBroker)
 					_, err := client.GetBrokerByName(ctx, ccSpaceScopedBroker.Name)
 
 					Expect(err).To(HaveOccurred())

--- a/cf/service_broker_test.go
+++ b/cf/service_broker_test.go
@@ -2,6 +2,7 @@ package cf_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/Peripli/service-broker-proxy-cf/cf"
@@ -14,20 +15,40 @@ import (
 
 var _ = Describe("Client ServiceBroker", func() {
 	var (
-		client          *cf.PlatformClient
-		ccServer        *ghttp.Server
-		testBroker      *platform.ServiceBroker
-		ccResponseCode  int
-		ccResponse      interface{}
-		ccResponseErr   cfclient.CloudFoundryError
-		expectedRequest interface{}
-		ctx             context.Context
+		client              *cf.PlatformClient
+		ccServer            *ghttp.Server
+		testBroker          *platform.ServiceBroker
+		ccResponseCode      int
+		ccResponse          interface{}
+		ccResponseErr       cfclient.CloudFoundryError
+		ccGlobalBroker      cfclient.ServiceBroker
+		ccSpaceScopedBroker cfclient.ServiceBroker
+		expectedRequest     interface{}
+		ctx                 context.Context
 	)
 
 	assertBrokersFoundMatchTestBroker := func(expectedCount int, actualBrokers ...*platform.ServiceBroker) {
 		Expect(actualBrokers).To(HaveLen(expectedCount))
 		for _, b := range actualBrokers {
 			Expect(b).To(Equal(testBroker))
+		}
+	}
+
+	ccBrokersResponse := func(brokers ...cfclient.ServiceBroker) cfclient.ServiceBrokerResponse {
+		ccBrokersResources := make([]cfclient.ServiceBrokerResource, 0)
+		for _, broker := range brokers {
+			ccBrokersResources = append(ccBrokersResources, cfclient.ServiceBrokerResource{
+				Meta: cfclient.Meta{
+					Guid: broker.Guid,
+				},
+				Entity: broker,
+			})
+		}
+
+		return cfclient.ServiceBrokerResponse{
+			Count:     len(ccBrokersResources),
+			Pages:     1,
+			Resources: ccBrokersResources,
 		}
 	}
 
@@ -38,6 +59,20 @@ var _ = Describe("Client ServiceBroker", func() {
 			GUID:      "test-testBroker-guid",
 			Name:      "test-testBroker-name",
 			BrokerURL: "http://example.com",
+		}
+
+		ccGlobalBroker = cfclient.ServiceBroker{
+			Guid:      testBroker.GUID,
+			Name:      testBroker.Name,
+			BrokerURL: testBroker.BrokerURL,
+		}
+
+		spaceScopedSuffix := "-space-scoped"
+		ccSpaceScopedBroker = cfclient.ServiceBroker{
+			Guid:      testBroker.GUID + spaceScopedSuffix,
+			Name:      testBroker.Name + spaceScopedSuffix,
+			BrokerURL: testBroker.BrokerURL + spaceScopedSuffix,
+			SpaceGUID: "cf-space-guid",
 		}
 
 		ccServer = fakeCCServer(false)
@@ -85,11 +120,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when no brokers are found in CC", func() {
 			BeforeEach(func() {
-				ccResponse = cfclient.ServiceBrokerResponse{
-					Count:     0,
-					Pages:     1,
-					Resources: []cfclient.ServiceBrokerResource{},
-				}
+				ccResponse = ccBrokersResponse()
 				ccResponseCode = http.StatusOK
 			})
 
@@ -104,30 +135,25 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when brokers exist in CC", func() {
 			BeforeEach(func() {
-				ccResponse = cfclient.ServiceBrokerResponse{
-					Count: 1,
-					Pages: 1,
-					Resources: []cfclient.ServiceBrokerResource{
-						{
-							Meta: cfclient.Meta{
-								Guid: testBroker.GUID,
-							},
-							Entity: cfclient.ServiceBroker{
-								Name:      testBroker.Name,
-								BrokerURL: testBroker.BrokerURL,
-								Username:  brokerUsername,
-							},
-						},
-					},
-				}
 				ccResponseCode = http.StatusOK
 			})
 
 			It("returns all of the brokers", func() {
+				ccResponse = ccBrokersResponse(ccGlobalBroker)
 				brokers, err := client.GetBrokers(ctx)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				assertBrokersFoundMatchTestBroker(1, brokers...)
+			})
+
+			Context("space-scoped broker exists", func() {
+				It("returns only the global brokers", func() {
+					ccResponse = ccBrokersResponse(ccGlobalBroker, ccSpaceScopedBroker)
+					brokers, err := client.GetBrokers(ctx)
+
+					Expect(err).ShouldNot(HaveOccurred())
+					assertBrokersFoundMatchTestBroker(1, brokers...)
+				})
 			})
 		})
 	})
@@ -167,11 +193,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when a broker with the specified name does not exist in CC", func() {
 			BeforeEach(func() {
-				ccResponse = cfclient.ServiceBrokerResponse{
-					Count:     0,
-					Pages:     1,
-					Resources: []cfclient.ServiceBrokerResource{},
-				}
+				ccResponse = ccBrokersResponse()
 				ccResponseCode = http.StatusOK
 			})
 
@@ -184,22 +206,7 @@ var _ = Describe("Client ServiceBroker", func() {
 
 		Context("when a broker with the specified name exists in CC", func() {
 			BeforeEach(func() {
-				ccResponse = cfclient.ServiceBrokerResponse{
-					Count: 1,
-					Pages: 1,
-					Resources: []cfclient.ServiceBrokerResource{
-						{
-							Meta: cfclient.Meta{
-								Guid: testBroker.GUID,
-							},
-							Entity: cfclient.ServiceBroker{
-								Name:      brokerName,
-								BrokerURL: testBroker.BrokerURL,
-								Username:  brokerUsername,
-							},
-						},
-					},
-				}
+				ccResponse = ccBrokersResponse(ccGlobalBroker)
 				ccResponseCode = http.StatusOK
 			})
 
@@ -208,6 +215,21 @@ var _ = Describe("Client ServiceBroker", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				assertBrokersFoundMatchTestBroker(1, broker)
+			})
+
+			Context("when the broker is space-scoped", func() {
+				BeforeEach(func() {
+					ccResponse = ccBrokersResponse(ccSpaceScopedBroker)
+					ccResponseCode = http.StatusOK
+				})
+
+				It("returns an error", func() {
+					_, err := client.GetBrokerByName(ctx, ccSpaceScopedBroker.Name)
+
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(fmt.Sprintf("service broker with name %s, GUID %s and URL %s is space-scoped",
+						ccSpaceScopedBroker.Name, ccSpaceScopedBroker.Guid, ccSpaceScopedBroker.BrokerURL)))
+				})
 			})
 		})
 


### PR DESCRIPTION
Currently, when a new broker is about to be registered in CF, the agent might overtake a space scoped broker.

Another approach for solving the issue requires changes at the core proxy code.
[Here](https://github.com/Peripli/service-broker-proxy/blob/master/pkg/sbproxy/notifications/handlers/broker_handler.go#L109), instead of just logging the error, we can stop the registration - it is not a 100% sure that the error is caused by the broke not being present in the platform. If the error and the returned brokers are both nil - then that would mean that the broker is not registered in the platform.