### PR TITLE
Service Plan Visibilities V3

### DIFF
--- a/cf/cf_suite_test.go
+++ b/cf/cf_suite_test.go
@@ -1,12 +1,31 @@
 package cf_test
 
 import (
-	"testing"
-
+	"encoding/json"
+	"fmt"
+	"github.com/Peripli/service-broker-proxy-cf/cf"
+	"github.com/Peripli/service-broker-proxy/pkg/platform"
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"github.com/Peripli/service-manager/test/testutil"
+	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/gofrs/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 	"github.com/sirupsen/logrus"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	parallelRequestsMutex      sync.Mutex
+	logInterceptor             *testutil.LogInterceptor
+	maxAllowedParallelRequests int
+	parallelRequestsCounter    int
 )
 
 func TestCF(t *testing.T) {
@@ -14,13 +33,348 @@ func TestCF(t *testing.T) {
 	RunSpecs(t, "Service Broker Proxy CF Client Suite")
 }
 
-var logInterceptor *testutil.LogInterceptor
-
 var _ = BeforeSuite(func() {
 	logInterceptor = &testutil.LogInterceptor{}
 	logrus.AddHook(logInterceptor)
+
 })
 
 var _ = BeforeEach(func() {
 	logInterceptor.Reset()
 })
+
+// Context initialization methods
+var generateCFBrokers = func(count int) []*cfclient.ServiceBroker {
+	brokers := make([]*cfclient.ServiceBroker, 0)
+	for i := 0; i < count; i++ {
+		UUID, err := uuid.NewV4()
+		Expect(err).ShouldNot(HaveOccurred())
+		brokerGuid := "broker-" + UUID.String()
+		brokerName := fmt.Sprintf("broker%d", i)
+		brokers = append(brokers, &cfclient.ServiceBroker{
+			Guid: brokerGuid,
+			Name: reconcile.DefaultProxyBrokerPrefix + brokerName + "-" + brokerGuid,
+		})
+	}
+	return brokers
+}
+
+var generateCFServices = func(brokers []*cfclient.ServiceBroker, count int) map[string][]*cfclient.Service {
+	services := make(map[string][]*cfclient.Service)
+	for _, broker := range brokers {
+		for i := 0; i < count; i++ {
+			UUID, err := uuid.NewV4()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			serviceGUID := "service-" + UUID.String()
+			services[broker.Guid] = append(services[broker.Guid], &cfclient.Service{
+				Guid:              serviceGUID,
+				ServiceBrokerGuid: broker.Guid,
+			})
+		}
+	}
+	return services
+}
+
+var generateCFPlans = func(
+	servicesMap map[string][]*cfclient.Service,
+	plansToGenerate,
+	publicPlansToGenerate int,
+) map[string][]*cfclient.ServicePlan {
+
+	plans := make(map[string][]*cfclient.ServicePlan)
+	for _, services := range servicesMap {
+		for _, service := range services {
+			for i := 0; i < plansToGenerate; i++ {
+				UUID, err := uuid.NewV4()
+				Expect(err).ShouldNot(HaveOccurred())
+				plans[service.Guid] = append(plans[service.Guid], &cfclient.ServicePlan{
+					Guid:        "planGUID-" + UUID.String(),
+					UniqueId:    "planCatalogGUID-" + UUID.String(),
+					ServiceGuid: service.Guid,
+				})
+			}
+
+			for i := 0; i < publicPlansToGenerate; i++ {
+				UUID, err := uuid.NewV4()
+				Expect(err).ShouldNot(HaveOccurred())
+				plans[service.Guid] = append(plans[service.Guid], &cfclient.ServicePlan{
+					Guid:        "planGUID-" + UUID.String(),
+					UniqueId:    "planCatalogGUID-" + UUID.String(),
+					ServiceGuid: service.Guid,
+					Public:      true,
+				})
+			}
+		}
+	}
+	return plans
+}
+
+var generateCFVisibilities = func(
+	plansMap map[string][]*cfclient.ServicePlan,
+	organizations []cf.Organization,
+	services map[string][]*cfclient.Service,
+	brokers []*cfclient.ServiceBroker,
+) (map[string]*cf.ServicePlanVisibilitiesResponse, map[string][]*platform.Visibility) {
+
+	visibilities := make(map[string]*cf.ServicePlanVisibilitiesResponse)
+	expectedVisibilities := make(map[string][]*platform.Visibility, 0)
+	for _, plans := range plansMap {
+		for _, plan := range plans {
+			var brokerName string
+			for _, services := range services {
+				for _, service := range services {
+					if service.Guid == plan.ServiceGuid {
+						brokerName = ""
+						for _, cfBroker := range brokers {
+							if cfBroker.Guid == service.ServiceBrokerGuid {
+								brokerName = cfBroker.Name
+							}
+						}
+					}
+				}
+			}
+			Expect(brokerName).ToNot(BeEmpty())
+
+			if !plan.Public {
+
+				visibilities[plan.Guid] = &cf.ServicePlanVisibilitiesResponse{
+					Type:          string(cf.VisibilityType.ORGANIZATION),
+					Organizations: []cf.Organization{},
+				}
+				expectedVisibilities[plan.Guid] = []*platform.Visibility{}
+
+				for _, org := range organizations {
+					visibilities[plan.Guid].Organizations = append(visibilities[plan.Guid].Organizations, cf.Organization{
+						Name: org.Name,
+						Guid: org.Guid,
+					})
+					expectedVisibilities[plan.Guid] = append(expectedVisibilities[plan.Guid], &platform.Visibility{
+						Public:             false,
+						CatalogPlanID:      plan.UniqueId,
+						PlatformBrokerName: brokerName,
+						Labels: map[string]string{
+							"organization_guid": org.Guid,
+						},
+					})
+				}
+			} else {
+				expectedVisibilities[plan.Guid] = []*platform.Visibility{
+					{
+						Public:             true,
+						CatalogPlanID:      plan.UniqueId,
+						PlatformBrokerName: brokerName,
+						Labels:             make(map[string]string),
+					},
+				}
+			}
+		}
+	}
+
+	return visibilities, expectedVisibilities
+}
+
+var parallelRequestsChecker = func(f http.HandlerFunc) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		parallelRequestsMutex.Lock()
+		parallelRequestsCounter++
+		if parallelRequestsCounter > maxAllowedParallelRequests {
+			defer func() {
+				parallelRequestsMutex.Lock()
+				defer parallelRequestsMutex.Unlock()
+				Fail(fmt.Sprintf("Max allowed parallel requests is %d but %d were detected", maxAllowedParallelRequests, parallelRequestsCounter))
+			}()
+
+		}
+		parallelRequestsMutex.Unlock()
+		defer func() {
+			parallelRequestsMutex.Lock()
+			parallelRequestsCounter--
+			parallelRequestsMutex.Unlock()
+		}()
+
+		// Simulate a 80ms request
+		<-time.After(80 * time.Millisecond)
+		f(writer, request)
+	}
+}
+
+var parseFilterQuery = func(query, queryKey string) map[string]bool {
+	if query == "" {
+		return nil
+	}
+
+	prefix := queryKey + " IN "
+	Expect(query).To(HavePrefix(prefix))
+
+	query = strings.TrimPrefix(query, prefix)
+	items := strings.Split(query, ",")
+	Expect(items).ToNot(BeEmpty())
+
+	result := make(map[string]bool)
+	for _, item := range items {
+		result[item] = true
+	}
+	return result
+}
+
+var writeJSONResponse = func(respStruct interface{}, rw http.ResponseWriter) {
+	jsonResponse, err := json.Marshal(respStruct)
+	Expect(err).ToNot(HaveOccurred())
+
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(jsonResponse)
+}
+
+var getBrokerNames = func(cfBrokers []*cfclient.ServiceBroker) []string {
+	names := make([]string, 0, len(cfBrokers))
+	for _, cfBroker := range cfBrokers {
+		names = append(names, cfBroker.Name)
+	}
+	return names
+}
+
+var filterPlans = func(plans []*cfclient.ServicePlan, isPublic bool) []*cfclient.ServicePlan {
+	var publicPlans []*cfclient.ServicePlan
+	for _, plan := range plans {
+		if plan.Public == isPublic {
+			publicPlans = append(publicPlans, plan)
+		}
+	}
+
+	return publicPlans
+}
+
+var badRequestHandler = func(rw http.ResponseWriter, req *http.Request) {
+	rw.WriteHeader(http.StatusInternalServerError)
+	rw.Write([]byte(`{"description": "Expected"}`))
+}
+
+// TODO replace with V3
+var setCCBrokersResponse = func(server *ghttp.Server, cfBrokers []*cfclient.ServiceBroker) {
+	if cfBrokers == nil {
+		server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		filter := parseFilterQuery(req.URL.Query().Get("q"), "name")
+		var result []cfclient.ServiceBrokerResource
+		for _, broker := range cfBrokers {
+			if filter == nil || filter[broker.Name] {
+				result = append(result, cfclient.ServiceBrokerResource{
+					Entity: *broker,
+					Meta: cfclient.Meta{
+						Guid: broker.Guid,
+					},
+				})
+			}
+		}
+		response := cfclient.ServiceBrokerResponse{
+			Count:     len(result),
+			Pages:     1,
+			Resources: result,
+		}
+		writeJSONResponse(response, rw)
+	}))
+}
+
+// TODO replace with V3
+var setCCServicesResponse = func(server *ghttp.Server, cfServices map[string][]*cfclient.Service) {
+	if cfServices == nil {
+		server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		filter := parseFilterQuery(req.URL.Query().Get("q"), "service_broker_guid")
+		result := make([]cfclient.ServicesResource, 0, len(filter))
+		for _, services := range cfServices {
+			for _, service := range services {
+				if filter == nil || filter[service.ServiceBrokerGuid] {
+					result = append(result, cfclient.ServicesResource{
+						Entity: *service,
+						Meta: cfclient.Meta{
+							Guid: service.Guid,
+						},
+					})
+				}
+			}
+		}
+		response := cfclient.ServicesResponse{
+			Count:     len(result),
+			Pages:     1,
+			Resources: result,
+		}
+		writeJSONResponse(response, rw)
+	}))
+}
+
+// TODO replace with V3
+var setCCPlansResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan) {
+	if cfPlans == nil {
+		server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		filterQuery := parseFilterQuery(req.URL.Query().Get("q"), "service_guid")
+		planResources := make([]cfclient.ServicePlanResource, 0, len(filterQuery))
+		for _, plans := range cfPlans {
+			for _, plan := range plans {
+				if filterQuery == nil || filterQuery[plan.ServiceGuid] {
+					planResources = append(planResources, cfclient.ServicePlanResource{
+						Entity: *plan,
+						Meta: cfclient.Meta{
+							Guid: plan.Guid,
+						},
+					})
+				}
+			}
+		}
+		servicePlanResponse := cfclient.ServicePlansResponse{
+			Count:     len(planResources),
+			Pages:     1,
+			Resources: planResources,
+		}
+		writeJSONResponse(servicePlanResponse, rw)
+	}))
+}
+
+var setCCVisibilitiesGetResponse = func(server *ghttp.Server, cfVisibilitiesByPlanId map[string]*cf.ServicePlanVisibilitiesResponse) {
+	r := strings.NewReplacer("/v3/service_plans/", "", "/visibility", "")
+	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
+	if cfVisibilitiesByPlanId == nil {
+		server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		planId := r.Replace(req.RequestURI)
+		visibilitiesResponse, _ := cfVisibilitiesByPlanId[planId]
+
+		writeJSONResponse(visibilitiesResponse, rw)
+	}))
+}
+
+var setCCVisibilitiesUpdateResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
+	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
+	if cfPlans == nil || simulateError {
+		server.RouteToHandler(http.MethodPost, path, parallelRequestsChecker(badRequestHandler))
+		server.RouteToHandler(http.MethodPatch, path, parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodPost, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	server.RouteToHandler(http.MethodPatch, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+}
+
+var setCCVisibilitiesDeleteResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
+	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility/(?P<organization_guid>[A-Za-z0-9_-]+)`)
+	if cfPlans == nil || simulateError {
+		server.RouteToHandler(http.MethodDelete, path, parallelRequestsChecker(badRequestHandler))
+		return
+	}
+	server.RouteToHandler(http.MethodDelete, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+}

--- a/cf/cf_suite_test.go
+++ b/cf/cf_suite_test.go
@@ -43,8 +43,8 @@ var _ = BeforeEach(func() {
 	logInterceptor.Reset()
 })
 
-// Context initialization methods
-var generateCFBrokers = func(count int) []*cfclient.ServiceBroker {
+// Test Context initialization methods
+func generateCFBrokers(count int) []*cfclient.ServiceBroker {
 	brokers := make([]*cfclient.ServiceBroker, 0)
 	for i := 0; i < count; i++ {
 		UUID, err := uuid.NewV4()
@@ -59,7 +59,7 @@ var generateCFBrokers = func(count int) []*cfclient.ServiceBroker {
 	return brokers
 }
 
-var generateCFServices = func(brokers []*cfclient.ServiceBroker, count int) map[string][]*cfclient.Service {
+func generateCFServices(brokers []*cfclient.ServiceBroker, count int) map[string][]*cfclient.Service {
 	services := make(map[string][]*cfclient.Service)
 	for _, broker := range brokers {
 		for i := 0; i < count; i++ {
@@ -76,7 +76,7 @@ var generateCFServices = func(brokers []*cfclient.ServiceBroker, count int) map[
 	return services
 }
 
-var generateCFPlans = func(
+func generateCFPlans(
 	servicesMap map[string][]*cfclient.Service,
 	plansToGenerate,
 	publicPlansToGenerate int,
@@ -110,7 +110,7 @@ var generateCFPlans = func(
 	return plans
 }
 
-var generateCFVisibilities = func(
+func generateCFVisibilities(
 	plansMap map[string][]*cfclient.ServicePlan,
 	organizations []cf.Organization,
 	services map[string][]*cfclient.Service,
@@ -174,7 +174,7 @@ var generateCFVisibilities = func(
 	return visibilities, expectedVisibilities
 }
 
-var parallelRequestsChecker = func(f http.HandlerFunc) http.HandlerFunc {
+func parallelRequestsChecker(f http.HandlerFunc) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		parallelRequestsMutex.Lock()
 		parallelRequestsCounter++
@@ -199,7 +199,7 @@ var parallelRequestsChecker = func(f http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-var parseFilterQuery = func(query, queryKey string) map[string]bool {
+func parseFilterQuery(query, queryKey string) map[string]bool {
 	if query == "" {
 		return nil
 	}
@@ -218,7 +218,7 @@ var parseFilterQuery = func(query, queryKey string) map[string]bool {
 	return result
 }
 
-var writeJSONResponse = func(respStruct interface{}, rw http.ResponseWriter) {
+func writeJSONResponse(respStruct interface{}, rw http.ResponseWriter) {
 	jsonResponse, err := json.Marshal(respStruct)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -226,7 +226,7 @@ var writeJSONResponse = func(respStruct interface{}, rw http.ResponseWriter) {
 	rw.Write(jsonResponse)
 }
 
-var getBrokerNames = func(cfBrokers []*cfclient.ServiceBroker) []string {
+func getBrokerNames(cfBrokers []*cfclient.ServiceBroker) []string {
 	names := make([]string, 0, len(cfBrokers))
 	for _, cfBroker := range cfBrokers {
 		names = append(names, cfBroker.Name)
@@ -234,7 +234,7 @@ var getBrokerNames = func(cfBrokers []*cfclient.ServiceBroker) []string {
 	return names
 }
 
-var filterPlans = func(plans []*cfclient.ServicePlan, isPublic bool) []*cfclient.ServicePlan {
+func filterPlans(plans []*cfclient.ServicePlan, isPublic bool) []*cfclient.ServicePlan {
 	var publicPlans []*cfclient.ServicePlan
 	for _, plan := range plans {
 		if plan.Public == isPublic {
@@ -251,7 +251,7 @@ var badRequestHandler = func(rw http.ResponseWriter, req *http.Request) {
 }
 
 // TODO replace with V3
-var setCCBrokersResponse = func(server *ghttp.Server, cfBrokers []*cfclient.ServiceBroker) {
+func setCCBrokersResponse(server *ghttp.Server, cfBrokers []*cfclient.ServiceBroker) {
 	if cfBrokers == nil {
 		server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(badRequestHandler))
 		return
@@ -279,7 +279,7 @@ var setCCBrokersResponse = func(server *ghttp.Server, cfBrokers []*cfclient.Serv
 }
 
 // TODO replace with V3
-var setCCServicesResponse = func(server *ghttp.Server, cfServices map[string][]*cfclient.Service) {
+func setCCServicesResponse(server *ghttp.Server, cfServices map[string][]*cfclient.Service) {
 	if cfServices == nil {
 		server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(badRequestHandler))
 		return
@@ -309,7 +309,7 @@ var setCCServicesResponse = func(server *ghttp.Server, cfServices map[string][]*
 }
 
 // TODO replace with V3
-var setCCPlansResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan) {
+func setCCPlansResponse(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan) {
 	if cfPlans == nil {
 		server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(badRequestHandler))
 		return
@@ -338,7 +338,7 @@ var setCCPlansResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclie
 	}))
 }
 
-var setCCVisibilitiesGetResponse = func(server *ghttp.Server, cfVisibilitiesByPlanId map[string]*cf.ServicePlanVisibilitiesResponse) {
+func setCCVisibilitiesGetResponse(server *ghttp.Server, cfVisibilitiesByPlanId map[string]*cf.ServicePlanVisibilitiesResponse) {
 	r := strings.NewReplacer("/v3/service_plans/", "", "/visibility", "")
 	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
 	if cfVisibilitiesByPlanId == nil {
@@ -353,7 +353,7 @@ var setCCVisibilitiesGetResponse = func(server *ghttp.Server, cfVisibilitiesByPl
 	}))
 }
 
-var setCCVisibilitiesUpdateResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
+func setCCVisibilitiesUpdateResponse(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
 	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
 	if cfPlans == nil || simulateError {
 		server.RouteToHandler(http.MethodPost, path, parallelRequestsChecker(badRequestHandler))
@@ -368,7 +368,7 @@ var setCCVisibilitiesUpdateResponse = func(server *ghttp.Server, cfPlans map[str
 	}))
 }
 
-var setCCVisibilitiesDeleteResponse = func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
+func setCCVisibilitiesDeleteResponse(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan, simulateError bool) {
 	path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility/(?P<organization_guid>[A-Za-z0-9_-]+)`)
 	if cfPlans == nil || simulateError {
 		server.RouteToHandler(http.MethodDelete, path, parallelRequestsChecker(badRequestHandler))

--- a/cf/client.go
+++ b/cf/client.go
@@ -1,10 +1,16 @@
 package cf
 
 import (
-	"github.com/cloudfoundry-community/go-cfclient"
-
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
 	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
+	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/cloudfoundry-community/go-cfclient"
+	"io/ioutil"
+	"net/http"
 )
 
 const (
@@ -32,6 +38,42 @@ func (pc *PlatformClient) Visibility() platform.VisibilityClient {
 // CatalogFetcher returns platform client which can perform refetching of service broker catalogs
 func (pc *PlatformClient) CatalogFetcher() platform.CatalogFetcher {
 	return pc
+}
+
+func (pc *PlatformClient) DoRequest(ctx context.Context, method string, path string, body ...interface{}) ([]byte, error) {
+	var request *cfclient.Request
+
+	if body != nil {
+		buf := bytes.NewBuffer(nil)
+		err := json.NewEncoder(buf).Encode(body[0])
+		if err != nil {
+			return nil, err
+		}
+		request = pc.client.NewRequestWithBody(method, path, buf)
+	} else {
+		request = pc.client.NewRequest(method, path)
+	}
+
+	response, err := pc.client.DoRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			log.C(ctx).Warn("unable to close response body stream:", err)
+		}
+	}()
+	if response.StatusCode >= http.StatusBadRequest {
+		log.C(ctx).Error(fmt.Errorf("CF API %s %s returned status code %d", method, path, response.StatusCode), err)
+		return nil, err
+	}
+
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
 }
 
 // NewClient creates a new CF cf client from the specified configuration.

--- a/cf/client.go
+++ b/cf/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudfoundry-community/go-cfclient"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -25,6 +26,22 @@ type PlatformClient struct {
 	planResolver *cfmodel.PlanResolver
 }
 
+// PlatformClientRequest provides generic request to CF API
+type PlatformClientRequest struct {
+	CTX          context.Context
+	URL          string
+	Method       string
+	QueryParams  url.Values
+	RequestBody  interface{}
+	ResponseBody interface{}
+}
+
+// PlatformClientResponse provides async job url (if response status was 202) and the status code
+type PlatformClientResponse struct {
+	JobURL     string
+	StatusCode int
+}
+
 // Broker returns platform client which can perform platform broker operations
 func (pc *PlatformClient) Broker() platform.BrokerClient {
 	return pc
@@ -35,48 +52,70 @@ func (pc *PlatformClient) Visibility() platform.VisibilityClient {
 	return pc
 }
 
-// CatalogFetcher returns platform client which can perform refetching of service broker catalogs
+// CatalogFetcher returns platform client which can perform re-fetching of service broker catalogs
 func (pc *PlatformClient) CatalogFetcher() platform.CatalogFetcher {
 	return pc
 }
 
-func (pc *PlatformClient) DoRequest(ctx context.Context, method string, path string, body ...interface{}) ([]byte, error) {
+// MakeRequest making request to CF API with the given request params
+func (pc *PlatformClient) MakeRequest(req PlatformClientRequest) (*PlatformClientResponse, error) {
+	logger := log.C(req.CTX)
 	var request *cfclient.Request
 
-	if body != nil {
+	if req.QueryParams != nil {
+		req.URL = fmt.Sprintf("%s?%s", req.URL, req.QueryParams.Encode())
+	}
+
+	if req.RequestBody != nil {
 		buf := bytes.NewBuffer(nil)
-		err := json.NewEncoder(buf).Encode(body[0])
+		err := json.NewEncoder(buf).Encode(req.RequestBody)
 		if err != nil {
 			return nil, err
 		}
-		request = pc.client.NewRequestWithBody(method, path, buf)
+		request = pc.client.NewRequestWithBody(req.Method, req.URL, buf)
 	} else {
-		request = pc.client.NewRequest(method, path)
+		request = pc.client.NewRequest(req.Method, req.URL)
 	}
 
 	response, err := pc.client.DoRequest(request)
 	if err != nil {
 		return nil, err
 	}
+
+	if response.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("CF API %s %s returned status code %d", req.Method, req.URL, response.StatusCode)
+	}
+
+	result := &PlatformClientResponse{
+		JobURL:     response.Header.Get("Location"),
+		StatusCode: response.StatusCode,
+	}
+
+	if req.ResponseBody == nil {
+		return result, nil
+	}
+
 	defer func() {
 		if err := response.Body.Close(); err != nil {
-			log.C(ctx).Warn("unable to close response body stream:", err)
+			logger.Warn("unable to close response body stream:", err)
 		}
 	}()
-	if response.StatusCode >= http.StatusBadRequest {
-		log.C(ctx).Error(fmt.Errorf("CF API %s %s returned status code %d", method, path, response.StatusCode), err)
-		return nil, err
-	}
-
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
+		logger.Errorf("Error parsing response body for request %s %v", req.URL, err)
 		return nil, err
 	}
 
-	return responseBody, nil
+	err = json.Unmarshal(responseBody, &req.ResponseBody)
+	if err != nil {
+		logger.Errorf("Error converting response json to given interface for request %s %v", req.URL, err)
+		return nil, err
+	}
+
+	return result, nil
 }
 
-// NewClient creates a new CF cf client from the specified configuration.
+// NewClient creates a new CF client from the specified configuration.
 func NewClient(config *Settings) (*PlatformClient, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err

--- a/cf/client_test.go
+++ b/cf/client_test.go
@@ -1,6 +1,8 @@
 package cf_test
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -38,6 +40,16 @@ type mockRoute struct {
 	requestChecks expectedRequest
 	reaction      reactionResponse
 }
+
+var (
+	cl           *cf.PlatformClient
+	ccServer     *ghttp.Server
+	responseCode int
+	response     interface{}
+	requestPath  string
+	responseErr  cfclient.CloudFoundryError
+	ctx          context.Context
+)
 
 func appendRoutes(server *ghttp.Server, routes ...*mockRoute) {
 	for _, route := range routes {
@@ -237,6 +249,109 @@ var _ = Describe("Client", func() {
 				_, err := cf.NewClient(settings)
 
 				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("DoRequest", func() {
+		BeforeEach(func() {
+			ccServer = fakeCCServer(false)
+			_, cl = ccClientWithThrottling(ccServer.URL(), 50)
+			ctx = context.TODO()
+			requestPath = "/v2/some_route"
+		})
+
+		Describe("when a request does not contain body", func() {
+			BeforeEach(func() {
+				ccServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, requestPath),
+						ghttp.RespondWithJSONEncodedPtr(&responseCode, &response),
+					),
+				)
+			})
+
+			Context("when an error status code is returned by CF Client", func() {
+				BeforeEach(func() {
+					responseErr = cfclient.CloudFoundryError{
+						Code:        1009,
+						ErrorCode:   "err",
+						Description: "test err",
+					}
+
+					response = responseErr
+					responseCode = http.StatusInternalServerError
+				})
+
+				It("returns an error", func() {
+					_, err := cl.DoRequest(ctx, http.MethodGet, requestPath)
+
+					assertCFError(err, responseErr)
+				})
+			})
+
+			Context("when the request is successful", func() {
+				BeforeEach(func() {
+					responseCode = http.StatusOK
+					response = cfclient.AppResponse{
+						Count:     0,
+						Pages:     0,
+						NextUrl:   "",
+						Resources: []cfclient.AppResource{},
+					}
+				})
+
+				It("returns CF response", func() {
+					var appResponse cfclient.AppResponse
+					resp, err := cl.DoRequest(ctx, http.MethodGet, requestPath)
+					json.Unmarshal(resp, &appResponse)
+
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(appResponse).To(Equal(response))
+				})
+			})
+		})
+
+		Describe("when a request contains body", func() {
+			requestBody := struct {
+				Name      string `json:"name"`
+				BrokerURL string `json:"broker_url"`
+				Username  string `json:"auth_username,omitempty"`
+				Password  string `json:"auth_password,omitempty"`
+			}{
+				Name:      "",
+				BrokerURL: "",
+				Username:  "",
+				Password:  "",
+			}
+			BeforeEach(func() {
+				ccServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, requestPath),
+						ghttp.VerifyJSONRepresenting(requestBody),
+						ghttp.RespondWithJSONEncodedPtr(&responseCode, &response),
+					),
+				)
+			})
+			Context("when the request is successful", func() {
+				BeforeEach(func() {
+					responseCode = http.StatusOK
+					response = cfclient.AppResponse{
+						Count:     2,
+						Pages:     2,
+						NextUrl:   "",
+						Resources: []cfclient.AppResource{},
+					}
+				})
+
+				It("returns CF response", func() {
+					var appResponse cfclient.AppResponse
+					resp, err := cl.DoRequest(ctx, http.MethodPost, requestPath, requestBody)
+					json.Unmarshal(resp, &appResponse)
+
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(appResponse).To(Equal(response))
+				})
 			})
 		})
 	})

--- a/cf/client_test.go
+++ b/cf/client_test.go
@@ -2,7 +2,6 @@ package cf_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -253,7 +252,7 @@ var _ = Describe("Client", func() {
 		})
 	})
 
-	Describe("DoRequest", func() {
+	Describe("MakeRequest", func() {
 		BeforeEach(func() {
 			ccServer = fakeCCServer(false)
 			_, cl = ccClientWithThrottling(ccServer.URL(), 50)
@@ -284,7 +283,11 @@ var _ = Describe("Client", func() {
 				})
 
 				It("returns an error", func() {
-					_, err := cl.DoRequest(ctx, http.MethodGet, requestPath)
+					_, err := cl.MakeRequest(cf.PlatformClientRequest{
+						CTX:    ctx,
+						URL:    requestPath,
+						Method: http.MethodGet,
+					})
 
 					assertCFError(err, responseErr)
 				})
@@ -303,8 +306,12 @@ var _ = Describe("Client", func() {
 
 				It("returns CF response", func() {
 					var appResponse cfclient.AppResponse
-					resp, err := cl.DoRequest(ctx, http.MethodGet, requestPath)
-					json.Unmarshal(resp, &appResponse)
+					_, err := cl.MakeRequest(cf.PlatformClientRequest{
+						CTX:          ctx,
+						URL:          requestPath,
+						Method:       http.MethodGet,
+						ResponseBody: &appResponse,
+					})
 
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(appResponse).To(Equal(response))
@@ -346,8 +353,13 @@ var _ = Describe("Client", func() {
 
 				It("returns CF response", func() {
 					var appResponse cfclient.AppResponse
-					resp, err := cl.DoRequest(ctx, http.MethodPost, requestPath, requestBody)
-					json.Unmarshal(resp, &appResponse)
+					_, err := cl.MakeRequest(cf.PlatformClientRequest{
+						CTX:          ctx,
+						URL:          requestPath,
+						Method:       http.MethodPost,
+						RequestBody:  requestBody,
+						ResponseBody: &appResponse,
+					})
 
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(appResponse).To(Equal(response))

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -1,183 +1,123 @@
 package cf
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
-
 	"github.com/Peripli/service-broker-proxy-cf/cf/cfmodel"
+	"strings"
 
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"github.com/Peripli/service-manager/pkg/log"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	"github.com/pkg/errors"
 )
-
-// ServicePlanRequest represents a service plan request
-type ServicePlanRequest struct {
-	Public bool `json:"public"`
-}
 
 // EnableAccessForPlan implements service-broker-proxy/pkg/cf/ServiceVisibilityHandler.EnableAccessForPlan
 // and provides logic for enabling the service access for a specified plan by the plan's catalog GUID.
 func (pc *PlatformClient) EnableAccessForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest) error {
-	return pc.updateAccessForPlan(ctx, request, true)
+	logger := log.C(ctx)
+	plan, err := pc.validateRequestAndGetPlan(ctx, request)
+	if err != nil {
+		return err
+	}
+
+	if orgGUIDs, ok := request.Labels[OrgLabelKey]; ok && len(orgGUIDs) != 0 {
+		err := pc.AddOrganizationVisibilities(ctx, plan.CatalogPlanID, orgGUIDs)
+		if err != nil {
+			return fmt.Errorf("could not enable access for plan with GUID %s in organizations with GUID %s: %v",
+				plan.GUID, strings.Join(orgGUIDs, ", "), err)
+		}
+		logger.Infof("Enabled access for plan with GUID %s in organizations with GUID %s",
+			plan.GUID, strings.Join(orgGUIDs, ", "))
+	} else {
+		// We didn't receive a list of organizations means we need to make this plan to be Public
+		err := pc.UpdateServicePlanVisibility(ctx, plan.CatalogPlanID, VisibilityType.PUBLIC)
+		if err != nil {
+			return fmt.Errorf("could not enable public access for plan with GUID %s: %v", plan.GUID, err)
+		}
+
+		pc.planResolver.UpdatePlan(plan.CatalogPlanID, plan.BrokerName, true)
+	}
+
+	return nil
 }
 
 // DisableAccessForPlan implements service-broker-proxy/pkg/cf/ServiceVisibilityHandler.DisableAccessForPlan
 // and provides logic for disabling the service access for a specified plan by the plan's catalog GUID.
 func (pc *PlatformClient) DisableAccessForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest) error {
-	return pc.updateAccessForPlan(ctx, request, false)
-}
-
-func (pc *PlatformClient) updateAccessForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, isEnabled bool) error {
-	if request == nil {
-		return errors.Errorf("modify plan access request cannot be nil")
-	}
-
-	plan, found := pc.planResolver.GetPlan(request.CatalogPlanID, request.BrokerName)
-	if !found {
-		return errors.Errorf("no plan found with catalog id %s from service broker %s",
-			request.CatalogPlanID, request.BrokerName)
+	logger := log.C(ctx)
+	plan, err := pc.validateRequestAndGetPlan(ctx, request)
+	if err != nil {
+		return err
 	}
 
 	scheduler := reconcile.NewScheduler(ctx, pc.settings.Reconcile.MaxParallelRequests)
 	if orgGUIDs, ok := request.Labels[OrgLabelKey]; ok && len(orgGUIDs) != 0 {
-		log.C(ctx).Infof("Updating access for plan with catalog id %s in %d organizations ...",
-			plan.CatalogPlanID, len(orgGUIDs))
 		for _, orgGUID := range orgGUIDs {
-			pc.scheduleUpdateOrgVisibilityForPlan(ctx, request, scheduler, plan, isEnabled, orgGUID)
+			pc.scheduleDeleteOrgVisibilityForPlan(ctx, request, scheduler, plan.CatalogPlanID, orgGUID)
 		}
+
+		if err := scheduler.Await(); err != nil {
+			return fmt.Errorf("failed to disable visibilities for plan with GUID %s for organizations: %s: %v",
+				plan.GUID, strings.Join(orgGUIDs, ","), err)
+		}
+
+		logger.Infof("Disabled access for plan with GUID %s in organizations with GUID %s",
+			plan.GUID, strings.Join(orgGUIDs, ", "))
 	} else {
-		pc.scheduleUpdatePlan(ctx, request, scheduler, plan, isEnabled)
-	}
-	if err := scheduler.Await(); err != nil {
-		return fmt.Errorf("error while updating access for catalog plan with id %s: %v",
-			request.CatalogPlanID, err)
+		// We didn't receive a list of organizations means we need to delete all visibilities of this plan
+		err := pc.ReplaceOrganizationVisibilities(ctx, plan.CatalogPlanID, []string{})
+		if err != nil {
+			return fmt.Errorf("could not remove organizatiuons visibilities for plan with GUID %s: %v", plan.GUID, err)
+		}
+
+		pc.planResolver.UpdatePlan(plan.CatalogPlanID, plan.BrokerName, true)
 	}
 
 	return nil
 }
 
-func (pc *PlatformClient) scheduleUpdateOrgVisibilityForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isEnabled bool, orgGUID string) {
+func (pc *PlatformClient) scheduleDeleteOrgVisibilityForPlan(
+	ctx context.Context,
+	request *platform.ModifyPlanAccessRequest,
+	scheduler *reconcile.TaskScheduler,
+	catalogPlanId string,
+	orgGUID string) {
+
 	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
-		return pc.updateOrgVisibilityForPlan(ctx, plan, isEnabled, orgGUID)
+		err := pc.DeleteOrganizationVisibilities(ctx, catalogPlanId, orgGUID)
+		if err != nil {
+			return fmt.Errorf("could not disable access for plan with catalog id %s in organization with GUID %s: %v",
+				catalogPlanId, orgGUID, err)
+		}
+
+		return nil
 	}); schedulerErr != nil {
 		log.C(ctx).WithError(schedulerErr).
-			Errorf("Could not schedule task for update plan with catalog id %s", request.CatalogPlanID)
+			Errorf("Could not schedule task for delete plan with catalog id %s", request.CatalogPlanID)
 	}
 }
 
-func (pc *PlatformClient) scheduleUpdatePlan(ctx context.Context, request *platform.ModifyPlanAccessRequest, scheduler *reconcile.TaskScheduler, plan cfmodel.PlanData, isPublic bool) {
-	if schedulerErr := scheduler.Schedule(func(ctx context.Context) error {
-		return pc.updatePlan(ctx, plan, isPublic)
-	}); schedulerErr != nil {
-		log.C(ctx).Warningf("Could not schedule task for update plan with catalog id %s", request.CatalogPlanID)
-	}
-}
-
-func (pc *PlatformClient) updateOrgVisibilityForPlan(ctx context.Context, plan cfmodel.PlanData, isEnabled bool, orgGUID string) error {
+func (pc *PlatformClient) validateRequestAndGetPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest) (*cfmodel.PlanData, error) {
 	logger := log.C(ctx)
-	switch {
-	case plan.Public:
-		logger.Warnf("Plan with GUID %s is already public and therefore attempt to update access "+
-			"visibility for org with GUID %s will be ignored", plan.GUID, orgGUID)
-	case isEnabled:
-		if _, err := pc.client.CreateServicePlanVisibility(plan.GUID, orgGUID); err != nil {
-			return fmt.Errorf("could not enable access for plan with GUID %s in organization with GUID %s: %v",
-				plan.GUID, orgGUID, err)
-		}
-		logger.Infof("Enabled access for plan with GUID %s in organization with GUID %s",
-			plan.GUID, orgGUID)
-	case !isEnabled:
-		query := url.Values{"q": []string{fmt.Sprintf("service_plan_guid:%s;organization_guid:%s", plan.GUID, orgGUID)}}
-		if err := pc.deleteAccessVisibilities(ctx, query); err != nil {
-			return err
-		}
+	if request == nil {
+		return nil, errors.Errorf("Enable plan access request cannot be nil")
 	}
 
-	return nil
-}
-
-func (pc *PlatformClient) updatePlan(ctx context.Context, plan cfmodel.PlanData, isPublic bool) error {
-	query := url.Values{"q": []string{fmt.Sprintf("service_plan_guid:%s", plan.GUID)}}
-	if err := pc.deleteAccessVisibilities(ctx, query); err != nil {
-		return err
+	plan, found := pc.planResolver.GetPlan(request.CatalogPlanID, request.BrokerName)
+	if !found {
+		return nil, errors.Errorf("No plan found with catalog id %s from service broker %s",
+			request.CatalogPlanID, request.BrokerName)
 	}
 
-	if plan.Public == isPublic {
-		return nil
+	if plan.Public {
+		errorMessage := fmt.Sprintf("Plan with catalog id %s from service broker %s is already public",
+			request.CatalogPlanID, request.BrokerName)
+		logger.Warnf(errorMessage)
+		return nil, errors.Errorf(errorMessage)
 	}
 
-	if _, err := pc.UpdateServicePlan(ctx, plan.GUID, ServicePlanRequest{Public: isPublic}); err != nil {
-		return err
-	}
-
-	pc.planResolver.UpdatePlan(plan.CatalogPlanID, plan.BrokerName, isPublic)
-	return nil
-}
-
-func (pc *PlatformClient) deleteAccessVisibilities(ctx context.Context, query url.Values) error {
-	log.C(ctx).Infof("Fetching service plan visibilities with query %v ...", query)
-	servicePlanVisibilities, err := pc.client.ListServicePlanVisibilitiesByQuery(query)
-	if err != nil {
-		return err
-	}
-
-	for _, visibility := range servicePlanVisibilities {
-		if err := pc.client.DeleteServicePlanVisibility(visibility.Guid, false); err != nil {
-			return fmt.Errorf("could not disable access for plan with GUID %s in organization with GUID %s: %v",
-				visibility.ServicePlanGuid, visibility.OrganizationGuid, err)
-		}
-		log.C(ctx).Infof("Disabled access for plan with GUID %s in organization with GUID %s",
-			visibility.ServicePlanGuid, visibility.OrganizationGuid)
-	}
-
-	return nil
-}
-
-// UpdateServicePlan updates the public property of the plan with the specified GUID
-func (pc *PlatformClient) UpdateServicePlan(ctx context.Context, planGUID string, request ServicePlanRequest) (cfclient.ServicePlan, error) {
-	plan, err := pc.updateServicePlan(planGUID, request)
-	if err != nil {
-		err = fmt.Errorf("could not update service plan with GUID %s: %v", planGUID, err)
-	} else {
-		log.C(ctx).Infof("Service plan with GUID %s updated to public: %v", planGUID, request.Public)
-	}
-	return plan, err
-}
-
-func (pc *PlatformClient) updateServicePlan(planGUID string, request ServicePlanRequest) (cfclient.ServicePlan, error) {
-	var planResource cfclient.ServicePlanResource
-	buf := bytes.NewBuffer(nil)
-	if err := json.NewEncoder(buf).Encode(request); err != nil {
-		return cfclient.ServicePlan{}, err
-	}
-
-	req := pc.client.NewRequestWithBody(http.MethodPut, "/v2/service_plans/"+planGUID, buf)
-
-	response, err := pc.client.DoRequest(req)
-	if err != nil {
-		return cfclient.ServicePlan{}, err
-	}
-	if response.StatusCode != http.StatusCreated {
-		return cfclient.ServicePlan{}, errors.Errorf("response code: %d", response.StatusCode)
-	}
-
-	decoder := json.NewDecoder(response.Body)
-	defer response.Body.Close() // nolint
-	if err := decoder.Decode(&planResource); err != nil {
-		return cfclient.ServicePlan{}, errors.Wrap(err, "error decoding response body")
-	}
-
-	servicePlan := planResource.Entity
-	servicePlan.Guid = planResource.Meta.Guid
-
-	return servicePlan, nil
+	return &plan, nil
 }

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -24,10 +24,8 @@ func (pc *PlatformClient) EnableAccessForPlan(ctx context.Context, request *plat
 	}
 
 	if plan.Public {
-		errorMessage := fmt.Sprintf("Plan with catalog id %s from service broker %s is already public",
+		return errors.Errorf("Plan with catalog id %s from service broker %s is already public",
 			request.CatalogPlanID, request.BrokerName)
-
-		return errors.Errorf(errorMessage)
 	}
 
 	if orgGUIDs, ok := request.Labels[OrgLabelKey]; ok && len(orgGUIDs) != 0 {
@@ -63,10 +61,8 @@ func (pc *PlatformClient) DisableAccessForPlan(ctx context.Context, request *pla
 	scheduler := reconcile.NewScheduler(ctx, pc.settings.Reconcile.MaxParallelRequests)
 	if orgGUIDs, ok := request.Labels[OrgLabelKey]; ok && len(orgGUIDs) != 0 {
 		if plan.Public {
-			errorMessage := fmt.Sprintf("Plan with catalog id %s from service broker %s is public",
+			return errors.Errorf("Cannot disable plan access for orgs. Plan with catalog id %s from service broker %s is public",
 				request.CatalogPlanID, request.BrokerName)
-
-			return errors.Errorf(errorMessage)
 		}
 
 		for _, orgGUID := range orgGUIDs {

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -109,7 +109,7 @@ func (pc *PlatformClient) scheduleDeleteOrgVisibilityForPlan(
 		return nil
 	}); schedulerErr != nil {
 		log.C(ctx).WithError(schedulerErr).
-			Errorf("Scheduler error on delete plan with catalog id %s and org with GUID %s", request.CatalogPlanID, orgGUID)
+			Errorf("Scheduler error on disable access for plan with catalog id %s and org with GUID %s", request.CatalogPlanID, orgGUID)
 	}
 }
 

--- a/cf/service_access_test.go
+++ b/cf/service_access_test.go
@@ -236,7 +236,8 @@ var _ = Describe("Client Service Plan Access", func() {
 
 				err := disableAccessForPlan(ctx, &request)
 				Expect(err).To(MatchError(
-					MatchRegexp(fmt.Sprintf("Plan with catalog id %s from service broker %s is public", publicPlan.UniqueId, broker.Name))))
+					MatchRegexp(fmt.Sprintf("Cannot disable plan access for orgs. Plan with catalog id %s from service broker %s is public",
+						publicPlan.UniqueId, broker.Name))))
 			})
 		})
 

--- a/cf/service_access_test.go
+++ b/cf/service_access_test.go
@@ -3,1131 +3,316 @@ package cf_test
 import (
 	"context"
 	"fmt"
-	"net/http"
-
 	"github.com/Peripli/service-broker-proxy-cf/cf"
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
-	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/cloudfoundry-community/go-cfclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"strings"
 )
 
 var _ = Describe("Client Service Plan Access", func() {
-
-	type planRouteDetails struct {
-		planResource             cfclient.ServicePlanResource
-		visibilityResource       cfclient.ServicePlanVisibilityResource
-		getVisibilitiesResponse  cfclient.ServicePlanVisibilitiesResponse
-		createVisibilityRequest  map[string]string
-		createVisibilityResponse *cfclient.ServicePlanVisibilityResource
-		updatePlanRequest        *cf.ServicePlanRequest
-		updatePlanResponse       *cfclient.ServicePlanResource
-	}
-
 	const (
-		orgGUID                      = "orgGUID"
-		serviceGUID                  = "serviceGUID"
-		brokerGUIDForPublicPlan      = "publicBrokerGUID"
-		publicPlanGUID               = "publicPlanGUID"
-		brokerPrivateGUID            = "privatePlanGUID"
-		privatePlanGUID              = "privatePlanGUID"
-		brokerGUIDForLimitedPlan     = "limitedBrokerGUID"
-		limitedPlanGUID              = "limitedPlanGUID"
-		visibilityForPublicPlanGUID  = "visibilityForPublicPlanGUID"
-		visibilityForLimitedPlanGUID = "visibilityForLimitedPlanGUID"
+		org1Guid = "testorgguid1"
+		org2Guid = "testorgguid2"
+		org1Name = "org1Name"
+		org2Name = "org2Name"
 	)
 
 	var (
-		ccServer     *ghttp.Server
-		client       *cf.PlatformClient
-		validOrgData types.Labels
-		emptyOrgData types.Labels
-		err          error
-
-		ccResponseErrBody cfclient.CloudFoundryError
-		ccResponseErrCode int
-
-		publicPlan  cfclient.ServicePlanResource
-		privatePlan cfclient.ServicePlanResource
-		limitedPlan cfclient.ServicePlanResource
-
-		visibilityForLimitedPlan cfclient.ServicePlanVisibilityResource
-		visibilityForPublicPlan  cfclient.ServicePlanVisibilityResource
-		visibilityForPrivatePlan cfclient.ServicePlanVisibilityResource
-
-		getVisibilitiesForPublicPlanResponse  cfclient.ServicePlanVisibilitiesResponse
-		getVisibilitiesForLimitedPlanResponse cfclient.ServicePlanVisibilitiesResponse
-		getVisibilitiesForPrivatePlanResponse cfclient.ServicePlanVisibilitiesResponse
-
-		postVisibilityForLimitedPlanRequest map[string]string
-		postVisibilityForPrivatePlanRequest map[string]string
-
-		updatePlanToPublicRequest    cf.ServicePlanRequest
-		updatePlanToNonPublicRequest cf.ServicePlanRequest
-
-		updatedPublicPlanToPrivateResponse cfclient.ServicePlanResource
-		updatedPrivatePlanToPublicResponse cfclient.ServicePlanResource
-		updatedLimitedPlanToPublicResponse cfclient.ServicePlanResource
-
-		planDetails map[string]*planRouteDetails
-		routes      []*mockRoute
-
-		planGUID   string
-		brokerGUID string
-		orgData    types.Labels
-
-		getBrokersRoute       mockRoute
-		getServicesRoute      mockRoute
-		getPlansRoute         mockRoute
-		getVisibilitiesRoute  mockRoute
-		createVisibilityRoute mockRoute
-		deleteVisibilityRoute mockRoute
-		updatePlanRoute       mockRoute
-
-		ctx context.Context
+		generatedCFBrokers      []*cfclient.ServiceBroker
+		generatedCFServices     map[string][]*cfclient.Service
+		generatedCFPlans        map[string][]*cfclient.ServicePlan
+		generatedCFVisibilities map[string]*cf.ServicePlanVisibilitiesResponse
+		client                  *cf.PlatformClient
+		// expectedCFVisibilities  map[string][]*platform.Visibility
 	)
+
+	createCCServer := func(
+		brokers []*cfclient.ServiceBroker,
+		cfServices map[string][]*cfclient.Service,
+		cfPlans map[string][]*cfclient.ServicePlan,
+		cfVisibilities map[string]*cf.ServicePlanVisibilitiesResponse,
+	) *ghttp.Server {
+		server := fakeCCServer(false)
+		setCCBrokersResponse(server, brokers)
+		setCCServicesResponse(server, cfServices)
+		setCCPlansResponse(server, cfPlans)
+		setCCVisibilitiesGetResponse(server, cfVisibilities)
+		setCCVisibilitiesUpdateResponse(server, cfPlans, false)
+		setCCVisibilitiesDeleteResponse(server, cfPlans, false)
+
+		return server
+	}
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		ctx, err = log.Configure(ctx, &log.Settings{
-			Level:  "debug",
-			Format: "text",
-			Output: "ginkgowriter",
-		})
-		Expect(err).To(BeNil())
-
-		ccServer = fakeCCServer(true)
-
-		_, client = ccClient(ccServer.URL())
-
-		verifyReqReceived(ccServer, 1, http.MethodGet, "/v2/info")
-		verifyReqReceived(ccServer, 1, http.MethodPost, "/oauth/token")
-
-		validOrgData = types.Labels{}
-		validOrgData[cf.OrgLabelKey] = []string{orgGUID}
-
-		emptyOrgData = types.Labels{}
-		emptyOrgData[cf.OrgLabelKey] = []string{}
-
-		publicPlan = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: publicPlanGUID,
-				Url:  "http://example.com",
+		generatedCFBrokers = generateCFBrokers(2)
+		generatedCFServices = generateCFServices(generatedCFBrokers, 2)
+		generatedCFPlans = generateCFPlans(generatedCFServices, 2, 1)
+		generatedCFVisibilities, _ = generateCFVisibilities(
+			generatedCFPlans, []cf.Organization{
+				{
+					Name: org1Name,
+					Guid: org1Guid,
+				},
+				{
+					Name: org2Name,
+					Guid: org2Guid,
+				},
 			},
-			Entity: cfclient.ServicePlan{
-				Name:        "publicPlan",
-				ServiceGuid: serviceGUID,
-				UniqueId:    publicPlanGUID,
-				Public:      true,
-			},
-		}
+			generatedCFServices,
+			generatedCFBrokers)
 
-		privatePlan = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: privatePlanGUID,
-				Url:  "http://example.com",
-			},
-			Entity: cfclient.ServicePlan{
-				Name:        "privatePlan",
-				ServiceGuid: serviceGUID,
-				UniqueId:    privatePlanGUID,
-				Public:      false,
-			},
-		}
-
-		limitedPlan = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: limitedPlanGUID,
-				Url:  "http://example.com",
-			},
-			Entity: cfclient.ServicePlan{
-				Name:        "limitedPlan",
-				ServiceGuid: serviceGUID,
-				UniqueId:    limitedPlanGUID,
-				Public:      false,
-			},
-		}
-
-		visibilityForLimitedPlan = cfclient.ServicePlanVisibilityResource{
-			Meta: cfclient.Meta{
-				Guid: visibilityForLimitedPlanGUID,
-				Url:  "http://example.com",
-			},
-			Entity: cfclient.ServicePlanVisibility{
-				ServicePlanGuid:  limitedPlanGUID,
-				OrganizationGuid: orgGUID,
-				ServicePlanUrl:   "http://example.com",
-				OrganizationUrl:  "http://example.com",
-			},
-		}
-
-		visibilityForPublicPlan = cfclient.ServicePlanVisibilityResource{
-			Meta: cfclient.Meta{
-				Guid: visibilityForPublicPlanGUID,
-				Url:  "http://example.com",
-			},
-			Entity: cfclient.ServicePlanVisibility{
-				ServicePlanGuid: publicPlanGUID,
-				ServicePlanUrl:  "http://example.com",
-			},
-		}
-
-		getVisibilitiesForPublicPlanResponse = cfclient.ServicePlanVisibilitiesResponse{
-			Count: 1,
-			Pages: 1,
-			Resources: []cfclient.ServicePlanVisibilityResource{
-				visibilityForPublicPlan,
-			},
-		}
-		getVisibilitiesForLimitedPlanResponse = cfclient.ServicePlanVisibilitiesResponse{
-			Count: 1,
-			Pages: 1,
-			Resources: []cfclient.ServicePlanVisibilityResource{
-				visibilityForLimitedPlan,
-			},
-		}
-		getVisibilitiesForPrivatePlanResponse = cfclient.ServicePlanVisibilitiesResponse{
-			Count:     0,
-			Pages:     1,
-			Resources: []cfclient.ServicePlanVisibilityResource{},
-		}
-
-		postVisibilityForLimitedPlanRequest = map[string]string{
-			"service_plan_guid": limitedPlanGUID,
-			"organization_guid": orgGUID,
-		}
-
-		postVisibilityForPrivatePlanRequest = map[string]string{
-			"service_plan_guid": privatePlanGUID,
-			"organization_guid": orgGUID,
-		}
-
-		updatePlanToPublicRequest = cf.ServicePlanRequest{
-			Public: true,
-		}
-
-		updatePlanToNonPublicRequest = cf.ServicePlanRequest{
-			Public: false,
-		}
-
-		updatedPublicPlanToPrivateResponse = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: publicPlan.Meta.Guid,
-				Url:  publicPlan.Meta.Url,
-			},
-			Entity: cfclient.ServicePlan{
-				Guid:        publicPlan.Meta.Guid,
-				Name:        publicPlan.Entity.Name,
-				Public:      !publicPlan.Entity.Public,
-				ServiceGuid: publicPlan.Entity.ServiceGuid,
-			},
-		}
-
-		updatedPrivatePlanToPublicResponse = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: privatePlan.Meta.Guid,
-				Url:  privatePlan.Meta.Url,
-			},
-			Entity: cfclient.ServicePlan{
-				Guid:        privatePlan.Meta.Guid,
-				Name:        privatePlan.Entity.Name,
-				Public:      !privatePlan.Entity.Public,
-				ServiceGuid: privatePlan.Entity.ServiceGuid,
-			},
-		}
-
-		updatedLimitedPlanToPublicResponse = cfclient.ServicePlanResource{
-			Meta: cfclient.Meta{
-				Guid: limitedPlan.Meta.Guid,
-				Url:  limitedPlan.Meta.Url,
-			},
-			Entity: cfclient.ServicePlan{
-				Guid:        limitedPlan.Meta.Guid,
-				Name:        limitedPlan.Entity.Name,
-				Public:      !limitedPlan.Entity.Public,
-				ServiceGuid: limitedPlan.Entity.ServiceGuid,
-			},
-		}
-
-		ccResponseErrBody = cfclient.CloudFoundryError{
-			Code:        1009,
-			ErrorCode:   "err",
-			Description: "test err",
-		}
-		ccResponseErrCode = http.StatusInternalServerError
-
-		planDetails = make(map[string]*planRouteDetails, 3)
-
-		planDetails[publicPlanGUID] = &planRouteDetails{
-			planResource:            publicPlan,
-			visibilityResource:      visibilityForPublicPlan,
-			getVisibilitiesResponse: getVisibilitiesForPublicPlanResponse,
-			updatePlanRequest:       &updatePlanToNonPublicRequest,
-			updatePlanResponse:      &updatedPublicPlanToPrivateResponse,
-			// createVisibilityRequest remains unset as we do not perform creating of visibility for public plans
-			// createVisibilityResponse remains unset as we do not perform creating of visibility for public plans
-		}
-
-		planDetails[privatePlanGUID] = &planRouteDetails{
-			planResource:             privatePlan,
-			visibilityResource:       visibilityForPrivatePlan,
-			getVisibilitiesResponse:  getVisibilitiesForPrivatePlanResponse,
-			createVisibilityRequest:  postVisibilityForPrivatePlanRequest,
-			createVisibilityResponse: &visibilityForPrivatePlan,
-			updatePlanRequest:        &updatePlanToPublicRequest,
-			updatePlanResponse:       &updatedPrivatePlanToPublicResponse,
-		}
-
-		planDetails[limitedPlanGUID] = &planRouteDetails{
-			planResource:             limitedPlan,
-			visibilityResource:       visibilityForLimitedPlan,
-			getVisibilitiesResponse:  getVisibilitiesForLimitedPlanResponse,
-			createVisibilityRequest:  postVisibilityForLimitedPlanRequest,
-			createVisibilityResponse: &visibilityForLimitedPlan,
-			updatePlanRequest:        &updatePlanToPublicRequest,
-			updatePlanResponse:       &updatedLimitedPlanToPublicResponse,
-		}
-
-		routes = make([]*mockRoute, 0)
-
-		getPlansRoute = mockRoute{}
-		getVisibilitiesRoute = mockRoute{}
-		createVisibilityRoute = mockRoute{}
-		deleteVisibilityRoute = mockRoute{}
-		updatePlanRoute = mockRoute{}
+		parallelRequestsCounter = 0
+		maxAllowedParallelRequests = 3
 	})
 
-	prepareGetBrokersRoute := func() mockRoute {
-		return mockRoute{
-			requestChecks: expectedRequest{
-				Method:   http.MethodGet,
-				Path:     "/v2/service_brokers",
-				RawQuery: "results-per-page=100",
-			},
-			reaction: reactionResponse{
-				Code: http.StatusOK,
-				Body: cfclient.ServiceBrokerResponse{
-					Count: 1,
-					Pages: 1,
-					Resources: []cfclient.ServiceBrokerResource{
-						cfclient.ServiceBrokerResource{
-							Meta: cfclient.Meta{
-								Guid: brokerGUID,
-							},
-							Entity: cfclient.ServiceBroker{
-								Guid: brokerGUID,
-								Name: brokerGUID,
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	prepareGetServicesRoute := func() mockRoute {
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method:   http.MethodGet,
-				Path:     "/v2/services",
-				RawQuery: "results-per-page=100",
-			},
-			reaction: reactionResponse{
-				Code: http.StatusOK,
-				Body: cfclient.ServicesResponse{
-					Count: 1,
-					Pages: 1,
-					Resources: []cfclient.ServicesResource{
-						cfclient.ServicesResource{
-							Meta: cfclient.Meta{
-								Guid: serviceGUID,
-							},
-							Entity: cfclient.Service{
-								Guid:              serviceGUID,
-								ServiceBrokerGuid: brokerGUID,
-							},
-						},
-					},
-				},
-			},
-		}
-		return route
-	}
-
-	prepareGetPlansRoute := func(planGUIDs ...string) mockRoute {
-		response := cfclient.ServicePlansResponse{}
-
-		if planGUIDs == nil || len(planGUIDs) == 0 {
-			response = cfclient.ServicePlansResponse{
-				Count:     0,
-				Pages:     0,
-				NextUrl:   "",
-				Resources: []cfclient.ServicePlanResource{},
-			}
-		} else {
-			response = cfclient.ServicePlansResponse{
-				Count:     len(planGUIDs),
-				Pages:     1,
-				NextUrl:   "",
-				Resources: []cfclient.ServicePlanResource{},
-			}
-			for _, guid := range planGUIDs {
-				planResource := planDetails[guid].planResource
-				response.Resources = append(response.Resources, planResource)
-			}
-		}
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method:   http.MethodGet,
-				Path:     "/v2/service_plans",
-				RawQuery: "results-per-page=100",
-			},
-			reaction: reactionResponse{
-				Code: http.StatusOK,
-				Body: response,
-			},
+	enableAccessForPlan := func(ctx context.Context, req *platform.ModifyPlanAccessRequest) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
 		}
 
-		return route
+		return client.EnableAccessForPlan(ctx, req)
 	}
 
-	prepareGetVisibilitiesRoute := func(planGUID, orgGUID string) mockRoute {
-		var query string
-		Expect(planGUID).ShouldNot(BeEmpty())
-		if orgGUID != "" {
-			query = fmt.Sprintf("service_plan_guid:%s;organization_guid:%s", planGUID, orgGUID)
-		} else {
-			query = fmt.Sprintf("service_plan_guid:%s", planGUID)
+	disableAccessForPlan := func(ctx context.Context, req *platform.ModifyPlanAccessRequest) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
 		}
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method:   http.MethodGet,
-				Path:     "/v2/service_plan_visibilities",
-				RawQuery: encodeQuery(query),
-			},
-			reaction: reactionResponse{
-				Code: http.StatusOK,
-				Body: planDetails[planGUID].getVisibilitiesResponse,
-			},
-		}
-		return route
-	}
-	prepareDeleteVisibilityRoute := func(planGUID string) mockRoute {
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method:   http.MethodDelete,
-				Path:     fmt.Sprintf("/v2/service_plan_visibilities/%s", planDetails[planGUID].visibilityResource.Meta.Guid),
-				RawQuery: "async=false",
-			},
-			reaction: reactionResponse{
-				Code: http.StatusNoContent,
-			},
-		}
-		return route
-	}
 
-	prepareCreateVisibilityRoute := func(planGUID string) mockRoute {
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method: http.MethodPost,
-				Path:   "/v2/service_plan_visibilities",
-				Body:   planDetails[planGUID].createVisibilityRequest,
-			},
-			reaction: reactionResponse{
-				Code: http.StatusCreated,
-				Body: planDetails[planGUID].createVisibilityResponse,
-			},
-		}
-		return route
-	}
-
-	prepareUpdatePlanRoute := func(planGUID string) mockRoute {
-		route := mockRoute{
-			requestChecks: expectedRequest{
-				Method: http.MethodPut,
-				Path:   fmt.Sprintf("/v2/service_plans/%s", planGUID),
-				Body:   planDetails[planGUID].updatePlanRequest,
-			},
-			reaction: reactionResponse{
-				Code: http.StatusCreated,
-				Body: planDetails[planGUID].updatePlanResponse,
-			},
-		}
-		return route
-	}
-
-	verifyBehaviourWhenUpdatingAccessFailsToObtainValidPlanDetails := func(assertFunc func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func()) {
-		Context("when obtaining plan for catalog plan GUID fails", func() {
-			BeforeEach(func() {
-				planGUID = publicPlanGUID
-				brokerGUID = brokerGUIDForPublicPlan
-				orgData = validOrgData
-
-				getBrokersRoute = prepareGetBrokersRoute()
-				getServicesRoute = prepareGetServicesRoute()
-
-				routes = append(routes, &getBrokersRoute, &getServicesRoute, &getPlansRoute)
-			})
-
-			Context("when listing plans for catalog plan GUID fails", func() {
-				BeforeEach(func() {
-					getPlansRoute = prepareGetPlansRoute(planGUID)
-
-					getPlansRoute.reaction.Body = ccResponseErrBody
-					getPlansRoute.reaction.Code = ccResponseErrCode
-				})
-
-				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
-			})
-
-			Context("when no plan is found", func() {
-				BeforeEach(func() {
-					getPlansRoute = prepareGetPlansRoute()
-				})
-
-				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, fmt.Errorf("no plan found")))
-			})
-		})
-	}
-
-	verifyBehaviourUpdateAccessFailsWhenDeleteAccessVisibilitiesFails := func(assertFunc func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func()) {
-		Context("when deleteAccessVisibilities fails", func() {
-			Context("when getting plan visibilities by plan GUID and org GUID fails", func() {
-				BeforeEach(func() {
-					getVisibilitiesRoute.reaction.Error = ccResponseErrBody
-					getVisibilitiesRoute.reaction.Code = ccResponseErrCode
-				})
-
-				It("attempts to get visibilities", func() {
-					assertFunc(&orgData, &planGUID, &brokerGUID)()
-
-					verifyRouteHits(ccServer, 1, &getBrokersRoute)
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 0, &deleteVisibilityRoute)
-				})
-
-				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
-
-			})
-
-			Context("when deleting plan visibility fails", func() {
-				BeforeEach(func() {
-					deleteVisibilityRoute.reaction.Error = ccResponseErrBody
-					deleteVisibilityRoute.reaction.Code = ccResponseErrCode
-				})
-
-				It("attempts to delete visibilities", func() {
-					assertFunc(&orgData, &planGUID, &brokerGUID)()
-
-					verifyRouteHits(ccServer, 1, &getBrokersRoute)
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				})
-
-				It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
-			})
-		})
-	}
-
-	verifyBehaviourUpdateAccessFailsWhenUpdateServicePlanFails := func(assertFunc func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func()) {
-		Context("when updateServicePlan fails", func() {
-			BeforeEach(func() {
-				updatePlanRoute.reaction.Error = ccResponseErrBody
-				updatePlanRoute.reaction.Code = ccResponseErrCode
-			})
-
-			It("attempts to update plan", func() {
-				assertFunc(&orgData, &planGUID, &brokerGUID)()
-
-				verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-				verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				verifyRouteHits(ccServer, 1, &updatePlanRoute)
-			})
-
-			It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
-		})
-	}
-
-	verifyBehaviourUpdateAccessFailsWhenCreateAccessVisibilityFails := func(assertFunc func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func()) {
-		Context("when CreateServicePlanVisibility for the plan fails", func() {
-			BeforeEach(func() {
-				createVisibilityRoute.reaction.Error = ccResponseErrBody
-				createVisibilityRoute.reaction.Code = ccResponseErrCode
-			})
-
-			It("attempts to create service plan visibility", func() {
-				assertFunc(&orgData, &planGUID, &brokerGUID)()
-
-				verifyRouteHits(ccServer, 1, &createVisibilityRoute)
-			})
-
-			It("returns an error", assertFunc(&orgData, &planGUID, &brokerGUID, &ccResponseErrBody))
-		})
+		return client.DisableAccessForPlan(ctx, req)
 	}
 
 	AfterEach(func() {
-		ccServer.Close()
-	})
-
-	JustBeforeEach(func() {
-		appendRoutes(ccServer, routes...)
-	})
-
-	Describe("DisableAccessForPlan", func() {
-		disableAccessForPlan := func(ctx context.Context, request *platform.ModifyPlanAccessRequest) error {
-			if err := client.ResetCache(ctx); err != nil {
-				return err
-			}
-			return client.DisableAccessForPlan(ctx, request)
+		if ccServer != nil {
+			ccServer.Close()
+			ccServer = nil
 		}
-
-		assertDisableAccessForPlanReturnsNoErr := func(data *types.Labels, planGUID, brokerGUID *string) func() {
-			return func() {
-				Expect(data).ShouldNot(BeNil())
-				Expect(planGUID).ShouldNot(BeNil())
-
-				err = disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-					BrokerName:    *brokerGUID,
-					CatalogPlanID: *planGUID,
-					Labels:        *data,
-				})
-
-				Expect(err).ShouldNot(HaveOccurred())
-			}
-		}
-
-		assertDisableAccessForPlanReturnsErr := func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func() {
-			return func() {
-				Expect(data).ShouldNot(BeNil())
-				Expect(planGUID).ShouldNot(BeNil())
-
-				err := disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-					BrokerName:    *brokerGUID,
-					CatalogPlanID: *planGUID,
-					Labels:        *data,
-				})
-
-				Expect(err).Should(HaveOccurred())
-				if expectedError == nil || len(expectedError) == 0 {
-					return
-				}
-				log.D().Error(err)
-				Expect(logInterceptor.String()).To(ContainSubstring(expectedError[0].Error()))
-			}
-		}
-
-		verifyBehaviourWhenUpdatingAccessFailsToObtainValidPlanDetails(assertDisableAccessForPlanReturnsErr)
-
-		Context("when disabling access for single plan for specific org", func() {
-			setupRoutes := func(guid, brokerguid string) {
-				planGUID = guid
-				brokerGUID = brokerguid
-				orgData = validOrgData
-				getBrokersRoute = prepareGetBrokersRoute()
-				getServicesRoute = prepareGetServicesRoute()
-				getPlansRoute = prepareGetPlansRoute(planGUID)
-				getVisibilitiesRoute = prepareGetVisibilitiesRoute(planGUID, orgGUID)
-				deleteVisibilityRoute = prepareDeleteVisibilityRoute(planGUID)
-
-				routes = append(routes, &getBrokersRoute, &getServicesRoute, &getPlansRoute, &getVisibilitiesRoute, &deleteVisibilityRoute)
-			}
-
-			Context("when an API call fails", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
-				})
-
-				verifyBehaviourUpdateAccessFailsWhenDeleteAccessVisibilitiesFails(assertDisableAccessForPlanReturnsErr)
-			})
-
-			Context("when the plan is public", func() {
-				BeforeEach(func() {
-					setupRoutes(publicPlanGUID, brokerGUIDForPublicPlan)
-				})
-
-				It("does not attempt to delete visibilities", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        validOrgData,
-					})
-
-					// verifyRouteHits(ccServer, 0, &getBrokersRoute)
-					verifyRouteHits(ccServer, 0, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 0, &deleteVisibilityRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&validOrgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is limited", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
-				})
-
-				It("deletes visibilities for the plan", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        validOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&validOrgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is private", func() {
-				BeforeEach(func() {
-					setupRoutes(privatePlanGUID, brokerPrivateGUID)
-				})
-
-				It("does not attempt to delete visibilities as none exist", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        validOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 0, &deleteVisibilityRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&validOrgData, &planGUID, &brokerGUID))
-			})
-		})
-
-		Context("when disabling access for single plan for all orgs", func() {
-			setupRoutes := func(guid, brokerguid string) {
-				planGUID = guid
-				brokerGUID = brokerguid
-				orgData = emptyOrgData
-				getBrokersRoute = prepareGetBrokersRoute()
-				getServicesRoute = prepareGetServicesRoute()
-				getPlansRoute = prepareGetPlansRoute(planGUID)
-				getVisibilitiesRoute = prepareGetVisibilitiesRoute(planGUID, "")
-				if planGUID != privatePlanGUID {
-					deleteVisibilityRoute = prepareDeleteVisibilityRoute(planGUID)
-				}
-				updatePlanRoute = prepareUpdatePlanRoute(planGUID)
-
-				routes = append(routes, &getBrokersRoute, &getServicesRoute, &getPlansRoute, &getVisibilitiesRoute, &deleteVisibilityRoute, &updatePlanRoute)
-			}
-
-			Context("when an API call fails", func() {
-				BeforeEach(func() {
-					setupRoutes(publicPlanGUID, brokerGUIDForPublicPlan)
-				})
-
-				verifyBehaviourUpdateAccessFailsWhenDeleteAccessVisibilitiesFails(assertDisableAccessForPlanReturnsErr)
-
-				verifyBehaviourUpdateAccessFailsWhenUpdateServicePlanFails(assertDisableAccessForPlanReturnsErr)
-			})
-
-			Context("when the plan is public", func() {
-				BeforeEach(func() {
-					setupRoutes(publicPlanGUID, brokerGUIDForPublicPlan)
-				})
-
-				It("deletes visibilities for the plan if any are found", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				})
-
-				It("updates the plan to private", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &updatePlanRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&emptyOrgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is limited", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
-				})
-
-				It("deletes visibilities for the plan if any are found", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				})
-
-				It("does not try to update the plan", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 0, &updatePlanRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&emptyOrgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is private", func() {
-				BeforeEach(func() {
-					setupRoutes(privatePlanGUID, brokerPrivateGUID)
-				})
-
-				It("does not delete visibilities as none are found", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 0, &deleteVisibilityRoute)
-				})
-
-				It("does not try to update the plan", func() {
-					disableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        emptyOrgData,
-					})
-
-					verifyRouteHits(ccServer, 0, &updatePlanRoute)
-				})
-
-				It("returns no error", assertDisableAccessForPlanReturnsNoErr(&emptyOrgData, &planGUID, &brokerGUID))
-			})
-		})
 	})
 
 	Describe("EnableAccessForPlan", func() {
-		enableAccessForPlan := func(ctx context.Context, request *platform.ModifyPlanAccessRequest) error {
-			if err := client.ResetCache(ctx); err != nil {
-				return err
-			}
-			return client.EnableAccessForPlan(ctx, request)
-		}
+		BeforeEach(func() {
+			ccServer = createCCServer(generatedCFBrokers, generatedCFServices, generatedCFPlans, generatedCFVisibilities)
+			_, client = ccClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests)
+		})
 
-		assertEnableAccessForPlanReturnsNoErr := func(data *types.Labels, planGUID, brokerGUID *string) func() {
-			return func() {
-				Expect(data).ShouldNot(BeNil())
-				Expect(planGUID).ShouldNot(BeNil())
+		Context("when invalid request", func() {
+			It("should return error if request is nil", func() {
+				error := enableAccessForPlan(ctx, nil)
 
-				err = enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-					BrokerName:    *brokerGUID,
-					CatalogPlanID: *planGUID,
-					Labels:        *data,
-				})
-
-				Expect(err).ShouldNot(HaveOccurred())
-			}
-		}
-
-		assertEnableAccessForPlanReturnsErr := func(data *types.Labels, planGUID, brokerGUID *string, expectedError ...error) func() {
-			return func() {
-				Expect(data).ShouldNot(BeNil())
-				Expect(planGUID).ShouldNot(BeNil())
-
-				err := enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-					BrokerName:    *brokerGUID,
-					CatalogPlanID: *planGUID,
-					Labels:        *data,
-				})
-
-				Expect(err).Should(HaveOccurred())
-				if expectedError == nil || len(expectedError) == 0 {
-					return
+				Expect(error).To(MatchError(MatchRegexp("Enable plan access request cannot be nil")))
+			})
+			It("should return error if plan not found", func() {
+				brokerName := generatedCFBrokers[0].Name
+				catalogPlanId := "not_existing_plan"
+				request := platform.ModifyPlanAccessRequest{
+					BrokerName:    brokerName,
+					CatalogPlanID: catalogPlanId,
+					Labels:        types.Labels{},
 				}
-				log.D().Error(err)
-				Expect(logInterceptor.String()).To(ContainSubstring(expectedError[0].Error()))
-			}
-		}
-
-		verifyBehaviourWhenUpdatingAccessFailsToObtainValidPlanDetails(assertEnableAccessForPlanReturnsErr)
-
-		Context("when enabling plan access for single plan for specific org", func() {
-			setupRoutes := func(guid, brokerguid string) {
-				planGUID = guid
-				brokerGUID = brokerguid
-				orgData = validOrgData
-				getBrokersRoute = prepareGetBrokersRoute()
-				getServicesRoute = prepareGetServicesRoute()
-				getPlansRoute = prepareGetPlansRoute(planGUID)
-				createVisibilityRoute = prepareCreateVisibilityRoute(planGUID)
-
-				routes = append(routes, &getBrokersRoute, &getServicesRoute, &getPlansRoute, &createVisibilityRoute)
-			}
-			Context("when an API call fails", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
-				})
-
-				verifyBehaviourUpdateAccessFailsWhenCreateAccessVisibilityFails(assertEnableAccessForPlanReturnsErr)
+				error := enableAccessForPlan(ctx, &request)
+				Expect(error).To(MatchError(
+					MatchRegexp(fmt.Sprintf("No plan found with catalog id %s from service broker %s", catalogPlanId, brokerName))))
 			})
+			It("should return error if plan is public", func() {
+				broker := generatedCFBrokers[0]
+				publicPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], true)[0]
+				request := platform.ModifyPlanAccessRequest{
+					BrokerName:    broker.Name,
+					CatalogPlanID: publicPlan.UniqueId,
+					Labels:        types.Labels{},
+				}
 
-			Context("when the plan is public", func() {
-				BeforeEach(func() {
-					setupRoutes(publicPlanGUID, brokerGUIDForPublicPlan)
-				})
-
-				It("does not create new visibilities", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 0, &createVisibilityRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&orgData, &planGUID, &brokerGUID))
-
-			})
-
-			Context("when the plan is limited", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
-				})
-
-				It("creates a service plan visibility for the plan and org even if one is already present", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &createVisibilityRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&orgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is private", func() {
-				BeforeEach(func() {
-					setupRoutes(privatePlanGUID, brokerPrivateGUID)
-				})
-
-				It("creates a service plan visibility for the plan and org even if one is already present", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &createVisibilityRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&orgData, &planGUID, &brokerGUID))
+				error := enableAccessForPlan(ctx, &request)
+				Expect(error).To(MatchError(
+					MatchRegexp(fmt.Sprintf("Plan with catalog id %s from service broker %s is already public", publicPlan.UniqueId, broker.Name))))
 			})
 		})
 
-		Context("when enabling plan access for single plan for all orgs", func() {
-			setupRoutes := func(guid, brokerguid string) {
-				planGUID = guid
-				brokerGUID = brokerguid
-				orgData = emptyOrgData
-				getBrokersRoute = prepareGetBrokersRoute()
-				getServicesRoute = prepareGetServicesRoute()
-				getPlansRoute = prepareGetPlansRoute(planGUID)
-				getVisibilitiesRoute = prepareGetVisibilitiesRoute(planGUID, "")
-				if planGUID != privatePlanGUID {
-					deleteVisibilityRoute = prepareDeleteVisibilityRoute(planGUID)
-				}
-				updatePlanRoute = prepareUpdatePlanRoute(planGUID)
+		Context("when the organization guids was provided", func() {
+			Context("when AddOrganizationVisibilities successful", func() {
+				It("should add visibility for these organizations", func() {
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{"organization_guid": []string{org1Guid, org2Guid}},
+					}
 
-				routes = append(routes, &getBrokersRoute, &getServicesRoute, &getPlansRoute, &getVisibilitiesRoute, &deleteVisibilityRoute, &updatePlanRoute)
-			}
-
-			Context("when an API call fails", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
+					error := enableAccessForPlan(ctx, &request)
+					Expect(error).ShouldNot(HaveOccurred())
 				})
-
-				verifyBehaviourUpdateAccessFailsWhenDeleteAccessVisibilitiesFails(assertEnableAccessForPlanReturnsErr)
-
-				verifyBehaviourUpdateAccessFailsWhenUpdateServicePlanFails(assertEnableAccessForPlanReturnsErr)
 			})
 
-			Context("when the plan is public", func() {
-				BeforeEach(func() {
-					setupRoutes(publicPlanGUID, brokerGUIDForPublicPlan)
+			Context("when AddOrganizationVisibilities failed", func() {
+				It("should return error", func() {
+					setCCVisibilitiesUpdateResponse(ccServer, generatedCFPlans, true)
+
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{"organization_guid": []string{org1Guid, org2Guid}},
+					}
+
+					error := enableAccessForPlan(ctx, &request)
+					Expect(error).To(MatchError(
+						MatchRegexp(fmt.Sprintf("could not enable access for plan with GUID %s in organizations with GUID %s:",
+							organizationPlan.Guid, fmt.Sprintf("%s, %s", org1Guid, org2Guid)))))
 				})
+			})
+		})
 
-				It("deletes visibilities if any are found", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
+		Context("when the organization guids was not provided", func() {
+			Context("when UpdateServicePlanVisibility successful", func() {
+				It("should update plan visibility to Public", func() {
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{},
+					}
 
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
+					error := enableAccessForPlan(ctx, &request)
+					Expect(error).ShouldNot(HaveOccurred())
 				})
-
-				It("does not try to update the plan", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 0, &updatePlanRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&orgData, &planGUID, &brokerGUID))
 			})
 
-			Context("when the plan is limited", func() {
-				BeforeEach(func() {
-					setupRoutes(limitedPlanGUID, brokerGUIDForLimitedPlan)
+			Context("when UpdateServicePlanVisibility failed", func() {
+				It("should return error", func() {
+					setCCVisibilitiesUpdateResponse(ccServer, generatedCFPlans, true)
+
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{},
+					}
+
+					error := enableAccessForPlan(ctx, &request)
+					Expect(error).To(MatchError(
+						MatchRegexp(fmt.Sprintf("could not enable public access for plan with GUID %s:", organizationPlan.Guid))))
 				})
-
-				It("updates the plan to public", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &updatePlanRoute)
-				})
-
-				It("deletes visibilities if any are found", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 1, &deleteVisibilityRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&emptyOrgData, &planGUID, &brokerGUID))
-			})
-
-			Context("when the plan is private", func() {
-				BeforeEach(func() {
-					setupRoutes(privatePlanGUID, brokerPrivateGUID)
-				})
-
-				It("updates the plan to public", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &updatePlanRoute)
-				})
-
-				It("does not delete visibilities as none are found", func() {
-					enableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerGUID,
-						CatalogPlanID: planGUID,
-						Labels:        orgData,
-					})
-
-					verifyRouteHits(ccServer, 1, &getVisibilitiesRoute)
-					verifyRouteHits(ccServer, 0, &deleteVisibilityRoute)
-				})
-
-				It("returns no error", assertEnableAccessForPlanReturnsNoErr(&orgData, &planGUID, &brokerGUID))
 			})
 		})
 	})
 
-	Describe("updateServicePlan", func() {
-		var (
-			planGUID    string
-			requestBody cf.ServicePlanRequest
-			updatePlan  mockRoute
-		)
-
+	Describe("DisableAccessForPlan", func() {
 		BeforeEach(func() {
-			planGUID = publicPlanGUID
-			requestBody = *planDetails[planGUID].updatePlanRequest
-			updatePlan = mockRoute{
-				requestChecks: expectedRequest{
-					Method: http.MethodPut,
-					Path:   fmt.Sprintf("/v2/service_plans/%s", planGUID),
-					Body:   requestBody,
-				},
-			}
-
-			routes = append(routes, &updatePlan)
+			ccServer = createCCServer(generatedCFBrokers, generatedCFServices, generatedCFPlans, generatedCFVisibilities)
+			_, client = ccClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests)
 		})
 
-		Context("when an error status code is returned by CC", func() {
-			BeforeEach(func() {
-				updatePlan.reaction.Error = ccResponseErrBody
-				updatePlan.reaction.Code = ccResponseErrCode
+		Context("when invalid request", func() {
+			It("should return error if request is nil", func() {
+				error := disableAccessForPlan(ctx, nil)
+
+				Expect(error).To(MatchError(MatchRegexp("Enable plan access request cannot be nil")))
 			})
-
-			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
-
-				assertCFError(err, ccResponseErrBody)
-
+			It("should return error if plan not found", func() {
+				brokerName := generatedCFBrokers[0].Name
+				catalogPlanId := "not_existing_plan"
+				request := platform.ModifyPlanAccessRequest{
+					BrokerName:    brokerName,
+					CatalogPlanID: catalogPlanId,
+					Labels:        types.Labels{},
+				}
+				error := disableAccessForPlan(ctx, &request)
+				Expect(error).To(MatchError(
+					MatchRegexp(fmt.Sprintf("No plan found with catalog id %s from service broker %s", catalogPlanId, brokerName))))
 			})
-		})
+			It("should return error if plan is public", func() {
+				broker := generatedCFBrokers[0]
+				publicPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], true)[0]
+				request := platform.ModifyPlanAccessRequest{
+					BrokerName:    broker.Name,
+					CatalogPlanID: publicPlan.UniqueId,
+					Labels:        types.Labels{},
+				}
 
-		Context("when an unexpected status code is returned by CC", func() {
-			BeforeEach(func() {
-				updatePlan.reaction.Body = planDetails[planGUID].updatePlanResponse
-				updatePlan.reaction.Code = http.StatusOK
-			})
-
-			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
-
-				Expect(err).Should(HaveOccurred())
-
+				error := disableAccessForPlan(ctx, &request)
+				Expect(error).To(MatchError(
+					MatchRegexp(fmt.Sprintf("Plan with catalog id %s from service broker %s is already public", publicPlan.UniqueId, broker.Name))))
 			})
 		})
 
-		Context("when response body is invalid", func() {
-			BeforeEach(func() {
-				updatePlan.reaction.Body = InvalidJSON
-				updatePlan.reaction.Code = http.StatusCreated
+		Context("when the organization guids was provided", func() {
+			Context("when DeleteOrganizationVisibilities successful", func() {
+				It("should remove visibility for these organizations", func() {
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{"organization_guid": []string{org1Guid, org2Guid}},
+					}
+
+					error := disableAccessForPlan(ctx, &request)
+					Expect(error).ShouldNot(HaveOccurred())
+				})
 			})
 
-			It("returns an error", func() {
-				_, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
+			Context("when DeleteOrganizationVisibilities failed", func() {
+				It("should return error", func() {
+					setCCVisibilitiesDeleteResponse(ccServer, generatedCFPlans, true)
 
-				Expect(err).Should(HaveOccurred())
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					organizationGuids := []string{org1Guid, org2Guid}
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{"organization_guid": organizationGuids},
+					}
+
+					error := disableAccessForPlan(ctx, &request)
+					Expect(error).To(MatchError(
+						MatchRegexp(
+							fmt.Sprintf("failed to disable visibilities for plan with GUID %s for organizations: %s",
+								organizationPlan.Guid, strings.Join(organizationGuids, ",")))))
+				})
 			})
 		})
 
-		Context("when no error occurs", func() {
-			BeforeEach(func() {
-				updatePlan.reaction.Body = planDetails[planGUID].updatePlanResponse
-				updatePlan.reaction.Code = http.StatusCreated
+		Context("when the organization guids was not provided", func() {
+			Context("when ReplaceOrganizationVisibilities successful", func() {
+				It("should remove all organizations from visibility of this plan", func() {
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{},
+					}
+
+					error := disableAccessForPlan(ctx, &request)
+					Expect(error).ShouldNot(HaveOccurred())
+				})
 			})
 
-			It("returns the updated service plan", func() {
-				plan, err := client.UpdateServicePlan(ctx, planGUID, requestBody)
+			Context("when ReplaceOrganizationVisibilities failed", func() {
+				It("should return error", func() {
+					setCCVisibilitiesUpdateResponse(ccServer, generatedCFPlans, true)
 
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(plan).Should(BeEquivalentTo(planDetails[planGUID].updatePlanResponse.Entity))
+					broker := generatedCFBrokers[0]
+					organizationPlan := filterPlans(generatedCFPlans[generatedCFServices[broker.Guid][0].Guid], false)[0]
+					request := platform.ModifyPlanAccessRequest{
+						BrokerName:    broker.Name,
+						CatalogPlanID: organizationPlan.UniqueId,
+						Labels:        types.Labels{},
+					}
+
+					error := disableAccessForPlan(ctx, &request)
+					Expect(error).To(MatchError(
+						MatchRegexp(fmt.Sprintf("could not remove organizatiuons visibilities for plan with GUID %s:", organizationPlan.Guid))))
+				})
 			})
 		})
 	})

--- a/cf/service_access_test.go
+++ b/cf/service_access_test.go
@@ -211,7 +211,6 @@ var _ = Describe("Client Service Plan Access", func() {
 		Context("when invalid request", func() {
 			It("should return error if request is nil", func() {
 				err := disableAccessForPlan(ctx, nil)
-
 				Expect(err).To(MatchError(MatchRegexp("Enable plan access request cannot be nil")))
 			})
 			It("should return error if plan not found", func() {

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -255,17 +255,6 @@ func (pc *PlatformClient) updateServicePlanVisibilities(
 		return fmt.Errorf("update plan visibility to visibility type %s is not supported", visibilityType)
 	}
 
-	if visibilityType == VisibilityType.ORGANIZATION {
-		requestBody = UpdateOrganizationVisibilitiesRequest{
-			Type:          string(visibilityType),
-			Organizations: newOrganizations(organizationGUIDs),
-		}
-	} else {
-		requestBody = UpdateVisibilitiesRequest{
-			Type: string(visibilityType),
-		}
-	}
-
 	resp, err := pc.MakeRequest(PlatformClientRequest{
 		CTX:         ctx,
 		Method:      requestMethod,

--- a/cf/service_visibilities.go
+++ b/cf/service_visibilities.go
@@ -101,8 +101,8 @@ func (pc *PlatformClient) GetVisibilitiesByBrokers(ctx context.Context, brokerNa
 	return result, nil
 }
 
-// UpdateServicePlanVisibility updates service plan visibility type
-func (pc *PlatformClient) UpdateServicePlanVisibility(ctx context.Context, catalogPlanId string, visibilityType VisibilityTypeValue) error {
+// UpdateServicePlanVisibilityType updates service plan visibility type
+func (pc *PlatformClient) UpdateServicePlanVisibilityType(ctx context.Context, catalogPlanId string, visibilityType VisibilityTypeValue) error {
 	return pc.updateServicePlanVisibilities(ctx, http.MethodPatch, catalogPlanId, visibilityType)
 }
 

--- a/cf/service_visibilities_test.go
+++ b/cf/service_visibilities_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 			return err
 		}
 
-		err := client.UpdateServicePlanVisibility(ctx, planGUID, visibilityType)
+		err := client.UpdateServicePlanVisibilityType(ctx, planGUID, visibilityType)
 		if err != nil {
 			return err
 		}

--- a/cf/service_visibilities_test.go
+++ b/cf/service_visibilities_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -20,7 +21,12 @@ import (
 )
 
 var _ = Describe("Client Service Plan Visibilities", func() {
-	const orgGUID = "testorgguid"
+	const (
+		org1Guid = "testorgguid1"
+		org2Guid = "testorgguid2"
+		org1Name = "org1Name"
+		org2Name = "org2Name"
+	)
 
 	var (
 		ccServer                *ghttp.Server
@@ -29,8 +35,8 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		generatedCFBrokers      []*cfclient.ServiceBroker
 		generatedCFServices     map[string][]*cfclient.Service
 		generatedCFPlans        map[string][]*cfclient.ServicePlan
-		generatedCFVisibilities map[string]*cfclient.ServicePlanVisibility
-		expectedCFVisibilities  map[string]*platform.Visibility
+		generatedCFVisibilities map[string]*cf.ServicePlanVisibilitiesResponse
+		expectedCFVisibilities  map[string][]*platform.Visibility
 
 		maxAllowedParallelRequests int
 		parallelRequestsCounter    int
@@ -99,12 +105,11 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		return plans
 	}
 
-	generateCFVisibilities := func(plansMap map[string][]*cfclient.ServicePlan) (map[string]*cfclient.ServicePlanVisibility, map[string]*platform.Visibility) {
-		visibilities := make(map[string]*cfclient.ServicePlanVisibility)
-		expectedVisibilities := make(map[string]*platform.Visibility, 0)
+	generateCFVisibilities := func(plansMap map[string][]*cfclient.ServicePlan) (map[string]*cf.ServicePlanVisibilitiesResponse, map[string][]*platform.Visibility) {
+		visibilities := make(map[string]*cf.ServicePlanVisibilitiesResponse)
+		expectedVisibilities := make(map[string][]*platform.Visibility, 0)
 		for _, plans := range plansMap {
 			for _, plan := range plans {
-				visibilityGuid := "cfVisibilityForPlan_" + plan.Guid
 				var brokerName string
 				for _, services := range generatedCFServices {
 					for _, service := range services {
@@ -121,27 +126,46 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 				Expect(brokerName).ToNot(BeEmpty())
 
 				if !plan.Public {
-					visibilities[plan.Guid] = &cfclient.ServicePlanVisibility{
-						ServicePlanGuid:  plan.Guid,
-						ServicePlanUrl:   "http://example.com",
-						Guid:             visibilityGuid,
-						OrganizationGuid: orgGUID,
+					visibilities[plan.Guid] = &cf.ServicePlanVisibilitiesResponse{
+						Type: string(cf.VisibilityType.ORGANIZATION),
+						Organizations: []cf.Organization{
+							{
+								Guid: org1Guid,
+								Name: org1Name,
+							},
+							{
+								Guid: org2Guid,
+								Name: org2Name,
+							},
+						},
 					}
 
-					expectedVisibilities[plan.Guid] = &platform.Visibility{
-						Public:             false,
-						CatalogPlanID:      plan.UniqueId,
-						PlatformBrokerName: brokerName,
-						Labels: map[string]string{
-							client.VisibilityScopeLabelKey(): orgGUID,
+					expectedVisibilities[plan.Guid] = []*platform.Visibility{
+						{
+							Public:             false,
+							CatalogPlanID:      plan.UniqueId,
+							PlatformBrokerName: brokerName,
+							Labels: map[string]string{
+								client.VisibilityScopeLabelKey(): org1Guid,
+							},
+						},
+						{
+							Public:             false,
+							CatalogPlanID:      plan.UniqueId,
+							PlatformBrokerName: brokerName,
+							Labels: map[string]string{
+								client.VisibilityScopeLabelKey(): org2Guid,
+							},
 						},
 					}
 				} else {
-					expectedVisibilities[plan.Guid] = &platform.Visibility{
-						Public:             true,
-						CatalogPlanID:      plan.UniqueId,
-						PlatformBrokerName: brokerName,
-						Labels:             make(map[string]string),
+					expectedVisibilities[plan.Guid] = []*platform.Visibility{
+						{
+							Public:             true,
+							CatalogPlanID:      plan.UniqueId,
+							PlatformBrokerName: brokerName,
+							Labels:             make(map[string]string),
+						},
 					}
 				}
 			}
@@ -215,6 +239,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		rw.Write([]byte(`{"description": "Expected"}`))
 	}
 
+	// TODO replace with V3
 	setCCBrokersResponse := func(server *ghttp.Server, cfBrokers []*cfclient.ServiceBroker) {
 		if cfBrokers == nil {
 			server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(badRequestHandler))
@@ -242,6 +267,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		}))
 	}
 
+	// TODO replace with V3
 	setCCServicesResponse := func(server *ghttp.Server, cfServices map[string][]*cfclient.Service) {
 		if cfServices == nil {
 			server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(badRequestHandler))
@@ -271,6 +297,7 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		}))
 	}
 
+	// TODO replace with V3
 	setCCPlansResponse := func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan) {
 		if cfPlans == nil {
 			server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(badRequestHandler))
@@ -300,35 +327,23 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		}))
 	}
 
-	setCCVisibilitiesResponse := func(server *ghttp.Server, cfVisibilities map[string]*cfclient.ServicePlanVisibility) {
-		if cfVisibilities == nil {
-			server.RouteToHandler(http.MethodGet, "/v2/service_plan_visibilities", parallelRequestsChecker(badRequestHandler))
+	setCCVisibilitiesResponse := func(server *ghttp.Server, cfVisibilitiesByPlanId map[string]*cf.ServicePlanVisibilitiesResponse) {
+		r := strings.NewReplacer("/v3/service_plans/", "", "/visibility", "")
+		path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
+		if cfVisibilitiesByPlanId == nil {
+			server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(badRequestHandler))
 			return
 		}
-		server.RouteToHandler(http.MethodGet, "/v2/service_plan_visibilities", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
-			reqPlans := parseFilterQuery(req.URL.Query().Get("q"), "service_plan_guid")
-			Expect(reqPlans).ToNot(BeEmpty())
-			visibilityResources := make([]cfclient.ServicePlanVisibilityResource, 0, len(reqPlans))
-			for visibilityGuid, visibility := range cfVisibilities {
-				if reqPlans[visibility.ServicePlanGuid] {
-					visibilityResources = append(visibilityResources, cfclient.ServicePlanVisibilityResource{
-						Entity: *visibility,
-						Meta: cfclient.Meta{
-							Guid: visibilityGuid,
-						},
-					})
-				}
-			}
-			servicePlanResponse := cfclient.ServicePlanVisibilitiesResponse{
-				Count:     len(visibilityResources),
-				Pages:     1,
-				Resources: visibilityResources,
-			}
-			writeJSONResponse(servicePlanResponse, rw)
+		server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
+
+			planId := r.Replace(req.RequestURI)
+			visibilitiesResponse, _ := cfVisibilitiesByPlanId[planId]
+
+			writeJSONResponse(visibilitiesResponse, rw)
 		}))
 	}
 
-	createCCServer := func(brokers []*cfclient.ServiceBroker, cfServices map[string][]*cfclient.Service, cfPlans map[string][]*cfclient.ServicePlan, cfVisibilities map[string]*cfclient.ServicePlanVisibility) *ghttp.Server {
+	createCCServer := func(brokers []*cfclient.ServiceBroker, cfServices map[string][]*cfclient.Service, cfPlans map[string][]*cfclient.ServicePlan, cfVisibilities map[string]*cf.ServicePlanVisibilitiesResponse) *ghttp.Server {
 		server := fakeCCServer(false)
 		setCCBrokersResponse(server, brokers)
 		setCCServicesResponse(server, cfServices)
@@ -381,8 +396,10 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 				platformVisibilities, err := getVisibilitiesByBrokers(ctx, getBrokerNames(generatedCFBrokers))
 				Expect(err).ShouldNot(HaveOccurred())
 
-				for _, expectedCFVisibility := range expectedCFVisibilities {
-					Expect(platformVisibilities).Should(ContainElement(expectedCFVisibility))
+				for _, expectedCFVisibilities := range expectedCFVisibilities {
+					for _, expectedCFVisibility := range expectedCFVisibilities {
+						Expect(platformVisibilities).Should(ContainElement(expectedCFVisibility))
+					}
 				}
 			})
 		})
@@ -401,7 +418,9 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 						for _, plan := range generatedCFPlans[serviceGUID] {
 							planGUID := plan.Guid
 							expectedVis := expectedCFVisibilities[planGUID]
-							Expect(platformVisibilities).Should(ContainElement(expectedVis))
+							for _, expectedCFVisibility := range expectedVis {
+								Expect(platformVisibilities).Should(ContainElement(expectedCFVisibility))
+							}
 						}
 					}
 				}
@@ -443,7 +462,8 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 			It("should return error", func() {
 				_, err := getVisibilitiesByBrokers(ctx, getBrokerNames(generatedCFBrokers))
 				Expect(err).To(HaveOccurred())
-				Expect(logInterceptor.String()).To(MatchRegexp("Error requesting service plan visibilities.*Expected"))
+				k := logInterceptor.String()
+				Expect(k).To(MatchRegexp("Error requesting service plan visibilities."))
 			})
 		})
 	})

--- a/cf/service_visibilities_test.go
+++ b/cf/service_visibilities_test.go
@@ -2,17 +2,8 @@ package cf_test
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"regexp"
-	"strings"
-	"sync"
-	"time"
-
 	"github.com/Peripli/service-broker-proxy-cf/cf"
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
-	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/gofrs/uuid"
 	. "github.com/onsi/ginkgo"
@@ -29,326 +20,27 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 	)
 
 	var (
-		ccServer                *ghttp.Server
-		client                  *cf.PlatformClient
-		ctx                     context.Context
 		generatedCFBrokers      []*cfclient.ServiceBroker
 		generatedCFServices     map[string][]*cfclient.Service
 		generatedCFPlans        map[string][]*cfclient.ServicePlan
 		generatedCFVisibilities map[string]*cf.ServicePlanVisibilitiesResponse
 		expectedCFVisibilities  map[string][]*platform.Visibility
-
-		maxAllowedParallelRequests int
-		parallelRequestsCounter    int
-		parallelRequestsMutex      sync.Mutex
+		client                  *cf.PlatformClient
 	)
 
-	generateCFBrokers := func(count int) []*cfclient.ServiceBroker {
-		brokers := make([]*cfclient.ServiceBroker, 0)
-		for i := 0; i < count; i++ {
-			UUID, err := uuid.NewV4()
-			Expect(err).ShouldNot(HaveOccurred())
-			brokerGuid := "broker-" + UUID.String()
-			brokerName := fmt.Sprintf("broker%d", i)
-			brokers = append(brokers, &cfclient.ServiceBroker{
-				Guid: brokerGuid,
-				Name: reconcile.DefaultProxyBrokerPrefix + brokerName + "-" + brokerGuid,
-			})
-		}
-		return brokers
-	}
-
-	generateCFServices := func(brokers []*cfclient.ServiceBroker, count int) map[string][]*cfclient.Service {
-		services := make(map[string][]*cfclient.Service)
-		for _, broker := range brokers {
-			for i := 0; i < count; i++ {
-				UUID, err := uuid.NewV4()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				serviceGUID := "service-" + UUID.String()
-				services[broker.Guid] = append(services[broker.Guid], &cfclient.Service{
-					Guid:              serviceGUID,
-					ServiceBrokerGuid: broker.Guid,
-				})
-			}
-		}
-		return services
-	}
-
-	generateCFPlans := func(servicesMap map[string][]*cfclient.Service, plansToGenrate, publicPlansToGenerate int) map[string][]*cfclient.ServicePlan {
-		plans := make(map[string][]*cfclient.ServicePlan)
-
-		for _, services := range servicesMap {
-			for _, service := range services {
-				for i := 0; i < plansToGenrate; i++ {
-					UUID, err := uuid.NewV4()
-					Expect(err).ShouldNot(HaveOccurred())
-					plans[service.Guid] = append(plans[service.Guid], &cfclient.ServicePlan{
-						Guid:        "planGUID-" + UUID.String(),
-						UniqueId:    "planCatalogGUID-" + UUID.String(),
-						ServiceGuid: service.Guid,
-					})
-				}
-
-				for i := 0; i < publicPlansToGenerate; i++ {
-					UUID, err := uuid.NewV4()
-					Expect(err).ShouldNot(HaveOccurred())
-					plans[service.Guid] = append(plans[service.Guid], &cfclient.ServicePlan{
-						Guid:        "planGUID-" + UUID.String(),
-						UniqueId:    "planCatalogGUID-" + UUID.String(),
-						ServiceGuid: service.Guid,
-						Public:      true,
-					})
-				}
-			}
-		}
-		return plans
-	}
-
-	generateCFVisibilities := func(plansMap map[string][]*cfclient.ServicePlan) (map[string]*cf.ServicePlanVisibilitiesResponse, map[string][]*platform.Visibility) {
-		visibilities := make(map[string]*cf.ServicePlanVisibilitiesResponse)
-		expectedVisibilities := make(map[string][]*platform.Visibility, 0)
-		for _, plans := range plansMap {
-			for _, plan := range plans {
-				var brokerName string
-				for _, services := range generatedCFServices {
-					for _, service := range services {
-						if service.Guid == plan.ServiceGuid {
-							brokerName = ""
-							for _, cfBroker := range generatedCFBrokers {
-								if cfBroker.Guid == service.ServiceBrokerGuid {
-									brokerName = cfBroker.Name
-								}
-							}
-						}
-					}
-				}
-				Expect(brokerName).ToNot(BeEmpty())
-
-				if !plan.Public {
-					visibilities[plan.Guid] = &cf.ServicePlanVisibilitiesResponse{
-						Type: string(cf.VisibilityType.ORGANIZATION),
-						Organizations: []cf.Organization{
-							{
-								Guid: org1Guid,
-								Name: org1Name,
-							},
-							{
-								Guid: org2Guid,
-								Name: org2Name,
-							},
-						},
-					}
-
-					expectedVisibilities[plan.Guid] = []*platform.Visibility{
-						{
-							Public:             false,
-							CatalogPlanID:      plan.UniqueId,
-							PlatformBrokerName: brokerName,
-							Labels: map[string]string{
-								client.VisibilityScopeLabelKey(): org1Guid,
-							},
-						},
-						{
-							Public:             false,
-							CatalogPlanID:      plan.UniqueId,
-							PlatformBrokerName: brokerName,
-							Labels: map[string]string{
-								client.VisibilityScopeLabelKey(): org2Guid,
-							},
-						},
-					}
-				} else {
-					expectedVisibilities[plan.Guid] = []*platform.Visibility{
-						{
-							Public:             true,
-							CatalogPlanID:      plan.UniqueId,
-							PlatformBrokerName: brokerName,
-							Labels:             make(map[string]string),
-						},
-					}
-				}
-			}
-		}
-
-		return visibilities, expectedVisibilities
-	}
-
-	parallelRequestsChecker := func(f http.HandlerFunc) http.HandlerFunc {
-		return func(writer http.ResponseWriter, request *http.Request) {
-			parallelRequestsMutex.Lock()
-			parallelRequestsCounter++
-			if parallelRequestsCounter > maxAllowedParallelRequests {
-				defer func() {
-					parallelRequestsMutex.Lock()
-					defer parallelRequestsMutex.Unlock()
-					Fail(fmt.Sprintf("Max allowed parallel requests is %d but %d were detected", maxAllowedParallelRequests, parallelRequestsCounter))
-				}()
-
-			}
-			parallelRequestsMutex.Unlock()
-			defer func() {
-				parallelRequestsMutex.Lock()
-				parallelRequestsCounter--
-				parallelRequestsMutex.Unlock()
-			}()
-
-			// Simulate a 80ms request
-			<-time.After(80 * time.Millisecond)
-			f(writer, request)
-		}
-	}
-
-	parseFilterQuery := func(query, queryKey string) map[string]bool {
-		if query == "" {
-			return nil
-		}
-
-		prefix := queryKey + " IN "
-		Expect(query).To(HavePrefix(prefix))
-
-		query = strings.TrimPrefix(query, prefix)
-		items := strings.Split(query, ",")
-		Expect(items).ToNot(BeEmpty())
-
-		result := make(map[string]bool)
-		for _, item := range items {
-			result[item] = true
-		}
-		return result
-	}
-
-	writeJSONResponse := func(respStruct interface{}, rw http.ResponseWriter) {
-		jsonResponse, err := json.Marshal(respStruct)
-		Expect(err).ToNot(HaveOccurred())
-
-		rw.WriteHeader(http.StatusOK)
-		rw.Write(jsonResponse)
-	}
-
-	getBrokerNames := func(cfBrokers []*cfclient.ServiceBroker) []string {
-		names := make([]string, 0, len(cfBrokers))
-		for _, cfBroker := range cfBrokers {
-			names = append(names, cfBroker.Name)
-		}
-		return names
-	}
-
-	badRequestHandler := func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusInternalServerError)
-		rw.Write([]byte(`{"description": "Expected"}`))
-	}
-
-	// TODO replace with V3
-	setCCBrokersResponse := func(server *ghttp.Server, cfBrokers []*cfclient.ServiceBroker) {
-		if cfBrokers == nil {
-			server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(badRequestHandler))
-			return
-		}
-		server.RouteToHandler(http.MethodGet, "/v2/service_brokers", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
-			filter := parseFilterQuery(req.URL.Query().Get("q"), "name")
-			result := []cfclient.ServiceBrokerResource{}
-			for _, broker := range cfBrokers {
-				if filter == nil || filter[broker.Name] {
-					result = append(result, cfclient.ServiceBrokerResource{
-						Entity: *broker,
-						Meta: cfclient.Meta{
-							Guid: broker.Guid,
-						},
-					})
-				}
-			}
-			response := cfclient.ServiceBrokerResponse{
-				Count:     len(result),
-				Pages:     1,
-				Resources: result,
-			}
-			writeJSONResponse(response, rw)
-		}))
-	}
-
-	// TODO replace with V3
-	setCCServicesResponse := func(server *ghttp.Server, cfServices map[string][]*cfclient.Service) {
-		if cfServices == nil {
-			server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(badRequestHandler))
-			return
-		}
-		server.RouteToHandler(http.MethodGet, "/v2/services", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
-			filter := parseFilterQuery(req.URL.Query().Get("q"), "service_broker_guid")
-			result := make([]cfclient.ServicesResource, 0, len(filter))
-			for _, services := range cfServices {
-				for _, service := range services {
-					if filter == nil || filter[service.ServiceBrokerGuid] {
-						result = append(result, cfclient.ServicesResource{
-							Entity: *service,
-							Meta: cfclient.Meta{
-								Guid: service.Guid,
-							},
-						})
-					}
-				}
-			}
-			response := cfclient.ServicesResponse{
-				Count:     len(result),
-				Pages:     1,
-				Resources: result,
-			}
-			writeJSONResponse(response, rw)
-		}))
-	}
-
-	// TODO replace with V3
-	setCCPlansResponse := func(server *ghttp.Server, cfPlans map[string][]*cfclient.ServicePlan) {
-		if cfPlans == nil {
-			server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(badRequestHandler))
-			return
-		}
-		server.RouteToHandler(http.MethodGet, "/v2/service_plans", parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
-			filterQuery := parseFilterQuery(req.URL.Query().Get("q"), "service_guid")
-			planResources := make([]cfclient.ServicePlanResource, 0, len(filterQuery))
-			for _, plans := range cfPlans {
-				for _, plan := range plans {
-					if filterQuery == nil || filterQuery[plan.ServiceGuid] {
-						planResources = append(planResources, cfclient.ServicePlanResource{
-							Entity: *plan,
-							Meta: cfclient.Meta{
-								Guid: plan.Guid,
-							},
-						})
-					}
-				}
-			}
-			servicePlanResponse := cfclient.ServicePlansResponse{
-				Count:     len(planResources),
-				Pages:     1,
-				Resources: planResources,
-			}
-			writeJSONResponse(servicePlanResponse, rw)
-		}))
-	}
-
-	setCCVisibilitiesResponse := func(server *ghttp.Server, cfVisibilitiesByPlanId map[string]*cf.ServicePlanVisibilitiesResponse) {
-		r := strings.NewReplacer("/v3/service_plans/", "", "/visibility", "")
-		path := regexp.MustCompile(`/v3/service_plans/(?P<guid>[A-Za-z0-9_-]+)/visibility`)
-		if cfVisibilitiesByPlanId == nil {
-			server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(badRequestHandler))
-			return
-		}
-		server.RouteToHandler(http.MethodGet, path, parallelRequestsChecker(func(rw http.ResponseWriter, req *http.Request) {
-
-			planId := r.Replace(req.RequestURI)
-			visibilitiesResponse, _ := cfVisibilitiesByPlanId[planId]
-
-			writeJSONResponse(visibilitiesResponse, rw)
-		}))
-	}
-
-	createCCServer := func(brokers []*cfclient.ServiceBroker, cfServices map[string][]*cfclient.Service, cfPlans map[string][]*cfclient.ServicePlan, cfVisibilities map[string]*cf.ServicePlanVisibilitiesResponse) *ghttp.Server {
+	createCCServer := func(
+		brokers []*cfclient.ServiceBroker,
+		cfServices map[string][]*cfclient.Service,
+		cfPlans map[string][]*cfclient.ServicePlan,
+		cfVisibilities map[string]*cf.ServicePlanVisibilitiesResponse,
+	) *ghttp.Server {
 		server := fakeCCServer(false)
 		setCCBrokersResponse(server, brokers)
 		setCCServicesResponse(server, cfServices)
 		setCCPlansResponse(server, cfPlans)
-		setCCVisibilitiesResponse(server, cfVisibilities)
+		setCCVisibilitiesGetResponse(server, cfVisibilities)
+		setCCVisibilitiesUpdateResponse(server, cfPlans, false)
+		setCCVisibilitiesDeleteResponse(server, cfPlans, false)
 
 		return server
 	}
@@ -360,6 +52,53 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 		return client.GetVisibilitiesByBrokers(ctx, brokerNames)
 	}
 
+	updateVisibility := func(ctx context.Context, planGUID string, visibilityType cf.VisibilityTypeValue) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
+		}
+
+		err := client.UpdateServicePlanVisibility(ctx, planGUID, visibilityType)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	addVisibilities := func(ctx context.Context, planGUID string, organizationsGUID []string) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
+		}
+
+		err := client.AddOrganizationVisibilities(ctx, planGUID, organizationsGUID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	replaceVisibilities := func(ctx context.Context, planGUID string, organizationsGUID []string) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
+		}
+
+		err := client.ReplaceOrganizationVisibilities(ctx, planGUID, organizationsGUID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	deleteVisibilities := func(ctx context.Context, planGUID string, organizationsGUID string) error {
+		if err := client.ResetCache(ctx); err != nil {
+			return err
+		}
+
+		return client.DeleteOrganizationVisibilities(ctx, planGUID, organizationsGUID)
+	}
+
 	AfterEach(func() {
 		if ccServer != nil {
 			ccServer.Close()
@@ -369,11 +108,22 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-
 		generatedCFBrokers = generateCFBrokers(5)
 		generatedCFServices = generateCFServices(generatedCFBrokers, 10)
 		generatedCFPlans = generateCFPlans(generatedCFServices, 15, 2)
-		generatedCFVisibilities, expectedCFVisibilities = generateCFVisibilities(generatedCFPlans)
+		generatedCFVisibilities, expectedCFVisibilities = generateCFVisibilities(
+			generatedCFPlans, []cf.Organization{
+				{
+					Name: org1Name,
+					Guid: org1Guid,
+				},
+				{
+					Name: org2Name,
+					Guid: org2Guid,
+				},
+			},
+			generatedCFServices,
+			generatedCFBrokers)
 
 		parallelRequestsCounter = 0
 		maxAllowedParallelRequests = 3
@@ -467,4 +217,63 @@ var _ = Describe("Client Service Plan Visibilities", func() {
 			})
 		})
 	})
+
+	Describe("Modify service plan visibilities", func() {
+		servicePlanGuid, _ := uuid.NewV4()
+
+		Context("when service plan is not available", func() {
+			BeforeEach(func() {
+				ccServer = createCCServer(generatedCFBrokers, nil, nil, nil)
+				_, client = ccClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests)
+			})
+
+			It("updateVisibility should return error", func() {
+				err := updateVisibility(ctx, servicePlanGuid.String(), cf.VisibilityType.PUBLIC)
+				Expect(err).To(MatchError(MatchRegexp("Error requesting services.*Expected")))
+			})
+
+			It("addVisibilities should return error", func() {
+				err := addVisibilities(ctx, servicePlanGuid.String(), []string{org1Guid})
+				Expect(err).To(MatchError(MatchRegexp("Error requesting services.*Expected")))
+			})
+
+			It("replaceVisibilities should return error", func() {
+				err := replaceVisibilities(ctx, servicePlanGuid.String(), []string{org1Guid})
+				Expect(err).To(MatchError(MatchRegexp("Error requesting services.*Expected")))
+			})
+
+			It("deleteVisibilities should return error", func() {
+				err := deleteVisibilities(ctx, servicePlanGuid.String(), org1Guid)
+				Expect(err).To(MatchError(MatchRegexp("Error requesting services.*Expected")))
+			})
+		})
+
+		Context("when service plan and org available", func() {
+			BeforeEach(func() {
+				ccServer = createCCServer(generatedCFBrokers, generatedCFServices, generatedCFPlans, generatedCFVisibilities)
+				_, client = ccClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests)
+			})
+
+			It("updateVisibility should not return error", func() {
+				err := updateVisibility(ctx, servicePlanGuid.String(), cf.VisibilityType.PUBLIC)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("addVisibilities should not return error", func() {
+				err := addVisibilities(ctx, servicePlanGuid.String(), []string{org1Guid})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("replaceVisibilities should not return error", func() {
+				err := replaceVisibilities(ctx, servicePlanGuid.String(), []string{org1Guid})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("deleteVisibilities should not return error", func() {
+				err := deleteVisibilities(ctx, servicePlanGuid.String(), org1Guid)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
 })

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Peripli/service-broker-proxy v0.11.25
 	github.com/Peripli/service-manager v0.23.2
-	github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05
+	github.com/cloudfoundry-community/go-cfclient v0.0.0-20220701174305-34d8f2860a20
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
 	github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072 // indirect
 	github.com/gavv/httpexpect v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Peripli/service-broker-proxy v0.11.24 h1:3GDXJrWwNnxd0m8ru9yg84ZWNwH7EROsr501bH62Bl0=
-github.com/Peripli/service-broker-proxy v0.11.24/go.mod h1:dWblp8ORB2M+xm8lcNBMgYCjdgg4J666IFYebL68UMI=
 github.com/Peripli/service-broker-proxy v0.11.25 h1:8Oe8DSvunahGMOHwTPtDh+LbuzAIjfMjEVDay/G22no=
 github.com/Peripli/service-broker-proxy v0.11.25/go.mod h1:dWblp8ORB2M+xm8lcNBMgYCjdgg4J666IFYebL68UMI=
 github.com/Peripli/service-manager v0.23.2 h1:3YBMFUokTa8b5sNsWc9Pfz6g2dQcec78zNKMnsjAG3E=
@@ -80,8 +78,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05 h1:5Hbn8fSLiRX8dje5E22dk/6SuJnbd+pnwjFCGyb8St0=
-github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05/go.mod h1:UGbOgL5sX52jB/PUVKOeRC17QYX4Afsq+bsIeMCD4VA=
+github.com/cloudfoundry-community/go-cfclient v0.0.0-20220701174305-34d8f2860a20 h1:z/0J4p0mp9nJJ3jhPW/6m73wI4bkYvboed63bZt1/GM=
+github.com/cloudfoundry-community/go-cfclient v0.0.0-20220701174305-34d8f2860a20/go.mod h1:0FdHblxw7g3M2PPICOw9i8YZOHP9dZTHbJUtoxL7Z/E=
 github.com/cloudfoundry-community/go-cfenv v1.17.1-0.20171115121958-e84b5c116637/go.mod h1:2UgWvQTRXUuIZ/x3KnW6fk6CgPBhcV4UQb/UGIrUyyI=
 github.com/cloudfoundry-community/go-cfenv v1.18.0 h1:dOIRSHUSaj4r6Q9Cx+nzz2OytHt+QNKqtOuKTQsa+zw=
 github.com/cloudfoundry-community/go-cfenv v1.18.0/go.mod h1:qGMSI6lygPzqugFs9M1NFjJBtEPgl0MgT6drMFZGUoU=
@@ -535,11 +533,11 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c h1:HiAZXo96zOhVhtFHchj/ojzoxCFiPrp9/j0GtS38V3g=
 golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=


### PR DESCRIPTION
Partial migration for service plan visibilities.

Possible performance improvements for the service access:
`EnableAccessForPlan`:  
1. Single enable access request to `/v3/service_plans/:plan_guid/visibility` and `organizations ` payload instead of multiple requests for each organization as was implemented in V2.
2. Single request for changing the plan to Public access (no need to loop delete requests for each org visibility in this plan)

`DisableAccessForPlan`:
Single request to remove all visibilities from plan instead of loop delete requests for each visibility.