### PR TITLE
fix service access logic

### DIFF
--- a/cf/organizations.go
+++ b/cf/organizations.go
@@ -1,0 +1,48 @@
+package cf
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// CCOrganization CF CC partial Organization object
+type CCOrganization struct {
+	GUID string `json:"guid"`
+	Name string `json:"name"`
+}
+
+// CCListOrganizationsResponse CF CC pagination response for the Organizations list
+type CCListOrganizationsResponse struct {
+	Pagination CCPagination     `json:"pagination"`
+	Resources  []CCOrganization `json:"resources"`
+}
+
+func (pc *PlatformClient) ListOrganizationsByQuery(ctx context.Context, query url.Values) ([]CCOrganization, error) {
+	var organizations []CCOrganization
+	var organizationsResponse CCListOrganizationsResponse
+	request := PlatformClientRequest{
+		CTX:          ctx,
+		URL:          "/v3/organizations?" + query.Encode(),
+		Method:       http.MethodGet,
+		ResponseBody: &organizationsResponse,
+	}
+
+	for {
+		_, err := pc.MakeRequest(request)
+		if err != nil {
+			return []CCOrganization{}, errors.Wrap(err, "Error requesting organizations")
+		}
+
+		organizations = append(organizations, organizationsResponse.Resources...)
+
+		request.URL = organizationsResponse.Pagination.Next.Href
+		if request.URL == "" {
+			break
+		}
+	}
+
+	return organizations, nil
+}

--- a/cf/organizations_test.go
+++ b/cf/organizations_test.go
@@ -1,0 +1,101 @@
+package cf_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/Peripli/service-broker-proxy-cf/cf"
+	"github.com/Peripli/service-broker-proxy-cf/cf/internal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"net/url"
+)
+
+var _ = Describe("Organizations", func() {
+	var (
+		generatedCFOrganizations []*cf.CCOrganization
+		client                   *cf.PlatformClient
+	)
+
+	var query = url.Values{
+		cf.CCQueryParams.PageSize: []string{"100"},
+	}
+
+	createCCServer := func(organizations []*cf.CCOrganization) *ghttp.Server {
+		server := testhelper.FakeCCServer(false)
+		setCCGetOrganizationsResponse(server, organizations)
+
+		return server
+	}
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		generatedCFOrganizations = generateCFOrganizations(10)
+
+		parallelRequestsCounter = 0
+		maxAllowedParallelRequests = 3
+	})
+
+	AfterEach(func() {
+		if ccServer != nil {
+			ccServer.Close()
+			ccServer = nil
+		}
+	})
+
+	Describe("ListOrganizationsByQuery", func() {
+		Context("when an error status code is returned by CC", func() {
+			BeforeEach(func() {
+				ccServer = createCCServer(generatedCFOrganizations)
+				_, client = testhelper.CCClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests, JobPollTimeout)
+			})
+
+			It("returns an error", func() {
+				setCCGetOrganizationsResponse(ccServer, nil)
+				_, err := client.ListOrganizationsByQuery(ctx, query)
+
+				Expect(err).To(MatchError(MatchRegexp(fmt.Sprintf("Error requesting organizations.*%s", unknownError.Detail))))
+			})
+		})
+
+		Context("when no organizations are found in CC", func() {
+			BeforeEach(func() {
+				ccServer = createCCServer(nil)
+				_, client = testhelper.CCClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests, JobPollTimeout)
+			})
+
+			It("returns nil", func() {
+				orgs := make([]*cf.CCOrganization, 0)
+				setCCGetOrganizationsResponse(ccServer, orgs)
+				organizationsRes, err := client.ListOrganizationsByQuery(ctx, query)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(organizationsRes).To(BeNil())
+			})
+
+		})
+
+		Context("when organizations exist in CC", func() {
+			BeforeEach(func() {
+				ccServer = createCCServer(generatedCFOrganizations)
+				_, client = testhelper.CCClientWithThrottling(ccServer.URL(), maxAllowedParallelRequests, JobPollTimeout)
+			})
+
+			It("returns all of the organizations", func() {
+				organizationsRes, err := client.ListOrganizationsByQuery(ctx, query)
+
+				Expect(err).ShouldNot(HaveOccurred())
+
+				organizationsMap := make(map[string]cf.CCOrganization)
+				for _, org := range organizationsRes {
+					organizationsMap[org.GUID] = org
+				}
+
+				for _, generatedOrg := range generatedCFOrganizations {
+					Expect(generatedOrg.GUID).To(Equal(organizationsMap[generatedOrg.GUID].GUID))
+					Expect(generatedOrg.Name).To(Equal(organizationsMap[generatedOrg.GUID].Name))
+				}
+			})
+		})
+	})
+})

--- a/cf/platform_client.go
+++ b/cf/platform_client.go
@@ -81,11 +81,13 @@ var CCQueryParams = struct {
 	Names                string
 	ServiceBrokerGuids   string
 	ServiceOfferingGuids string
+	GUIDs                string
 }{
 	PageSize:             "per_page",
 	Names:                "names",
 	ServiceBrokerGuids:   "service_broker_guids",
 	ServiceOfferingGuids: "service_offering_guids",
+	GUIDs:                "guids",
 }
 
 // Broker returns platform client which can perform platform broker operations

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -3,6 +3,8 @@ package cf
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
@@ -28,7 +30,18 @@ func (pc *PlatformClient) EnableAccessForPlan(ctx context.Context, request *plat
 	}
 
 	if orgGUIDs, ok := request.Labels[OrgLabelKey]; ok && len(orgGUIDs) != 0 {
-		err = pc.AddOrganizationVisibilities(ctx, plan.GUID, orgGUIDs)
+		existingOrgGUIDs := pc.getExistingOrgGUIDs(ctx, orgGUIDs)
+		if len(existingOrgGUIDs) == 0 {
+			return fmt.Errorf("could not enable access for plan with GUID %s in organizations with GUID %s because organizations is not exist",
+				plan.GUID, strings.Join(orgGUIDs, ", "))
+		}
+
+		if len(existingOrgGUIDs) != len(orgGUIDs) {
+			logger.Infof("Enabled access for plan with GUID %s in organizations with GUID %s will be executed only for existing organizations: %s",
+				plan.GUID, strings.Join(orgGUIDs, ", "), strings.Join(existingOrgGUIDs, ", "))
+		}
+
+		err = pc.AddOrganizationVisibilities(ctx, plan.GUID, existingOrgGUIDs)
 		if err != nil {
 			return fmt.Errorf("could not enable access for plan with GUID %s in organizations with GUID %s: %v",
 				plan.GUID, strings.Join(orgGUIDs, ", "), err)
@@ -120,4 +133,40 @@ func (pc *PlatformClient) validateRequestAndGetPlan(request *platform.ModifyPlan
 	}
 
 	return &plan, nil
+}
+
+func (pc *PlatformClient) getExistingOrgGUIDs(ctx context.Context, orgGUIDs []string) []string {
+	const chunkSize = 50
+	var chunkedGUIDs [][]string
+	var existingOrgGUIDs []string
+
+	// split guids into the chunks
+	for i := 0; i < len(orgGUIDs); i += chunkSize {
+		end := i + chunkSize
+		if end > len(orgGUIDs) {
+			end = len(orgGUIDs)
+		}
+
+		chunkedGUIDs = append(chunkedGUIDs, orgGUIDs[i:end])
+	}
+
+	for _, chunk := range chunkedGUIDs {
+		orgIds := strings.Join(chunk[:], ",")
+		query := url.Values{
+			CCQueryParams.PageSize: []string{strconv.Itoa(chunkSize)},
+			CCQueryParams.GUIDs:    []string{orgIds},
+		}
+
+		organizations, err := pc.ListOrganizationsByQuery(ctx, query)
+		if err != nil {
+			log.C(ctx).WithError(err).
+				Errorf("Error when trying to GET organizations: %s", orgIds)
+		}
+
+		for _, org := range organizations {
+			existingOrgGUIDs = append(existingOrgGUIDs, org.GUID)
+		}
+	}
+
+	return existingOrgGUIDs
 }

--- a/cf/service_access.go
+++ b/cf/service_access.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const GetOrganizationsChunkSize = 50
+
 // EnableAccessForPlan implements service-broker-proxy/pkg/cf/ServiceVisibilityHandler.EnableAccessForPlan
 // and provides logic for enabling the service access for a specified plan by the plan's catalog GUID.
 func (pc *PlatformClient) EnableAccessForPlan(ctx context.Context, request *platform.ModifyPlanAccessRequest) error {
@@ -136,13 +138,12 @@ func (pc *PlatformClient) validateRequestAndGetPlan(request *platform.ModifyPlan
 }
 
 func (pc *PlatformClient) getExistingOrgGUIDs(ctx context.Context, orgGUIDs []string) []string {
-	const chunkSize = 50
 	var chunkedGUIDs [][]string
 	var existingOrgGUIDs []string
 
 	// split guids into the chunks
-	for i := 0; i < len(orgGUIDs); i += chunkSize {
-		end := i + chunkSize
+	for i := 0; i < len(orgGUIDs); i += GetOrganizationsChunkSize {
+		end := i + GetOrganizationsChunkSize
 		if end > len(orgGUIDs) {
 			end = len(orgGUIDs)
 		}
@@ -153,7 +154,7 @@ func (pc *PlatformClient) getExistingOrgGUIDs(ctx context.Context, orgGUIDs []st
 	for _, chunk := range chunkedGUIDs {
 		orgIds := strings.Join(chunk[:], ",")
 		query := url.Values{
-			CCQueryParams.PageSize: []string{strconv.Itoa(chunkSize)},
+			CCQueryParams.PageSize: []string{strconv.Itoa(GetOrganizationsChunkSize)},
 			CCQueryParams.GUIDs:    []string{orgIds},
 		}
 


### PR DESCRIPTION
Fixes to enable service access for the plan:
1. First, we check if organizations exist in CF
2. We enable visibilities for only existing organizations by triggering the V3 API of service plan visibilities.

Added tests for different scenarios.
Added job polling logs for async service broker APIs for debugging purposes.